### PR TITLE
Clean-up network configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Clean-up network configuration](https://github.com/multiversx/mx-sdk-dapp-core/pull/97)
 - [FormatAmountController validation improvements](https://github.com/multiversx/mx-sdk-dapp-core/pull/96)
 - [Added setAxiosInterceptors utility function](https://github.com/multiversx/mx-sdk-dapp-core/pull/94)
 

--- a/src/constants/network.constants.ts
+++ b/src/constants/network.constants.ts
@@ -13,10 +13,6 @@ export const fallbackNetworkConfigurations: Record<
     decimals: '18',
     digits: '4',
     gasPerDataByte: '1500',
-    walletConnectDeepLink:
-      'https://maiar.page.link/?apn=com.elrond.maiar.wallet&isi=1519405832&ibi=com.elrond.maiar.wallet&link=https://xportal.com/',
-    walletConnectBridgeAddresses: ['https://bridge.walletconnect.org'],
-    walletConnectV2RelayAddresses: ['wss://relay.walletconnect.com'],
     walletAddress: 'https://devnet-wallet.multiversx.com',
     iframeWalletAddress: 'https://devnet-snap-wallet.multiversx.com',
     xAliasAddress: 'https://devnet.xalias.com',
@@ -33,10 +29,6 @@ export const fallbackNetworkConfigurations: Record<
     decimals: '18',
     digits: '4',
     gasPerDataByte: '1500',
-    walletConnectDeepLink:
-      'https://maiar.page.link/?apn=com.elrond.maiar.wallet&isi=1519405832&ibi=com.elrond.maiar.wallet&link=https://xportal.com/',
-    walletConnectBridgeAddresses: ['https://bridge.walletconnect.org'],
-    walletConnectV2RelayAddresses: ['wss://relay.walletconnect.com'],
     walletAddress: 'https://testnet-wallet.multiversx.com',
     iframeWalletAddress: 'https://testnet-snap-wallet.multiversx.com',
     xAliasAddress: 'https://testnet.xalias.com',
@@ -53,10 +45,6 @@ export const fallbackNetworkConfigurations: Record<
     decimals: '18',
     digits: '4',
     gasPerDataByte: '1500',
-    walletConnectDeepLink:
-      'https://maiar.page.link/?apn=com.elrond.maiar.wallet&isi=1519405832&ibi=com.elrond.maiar.wallet&link=https://xportal.com/',
-    walletConnectBridgeAddresses: ['https://bridge.walletconnect.org'],
-    walletConnectV2RelayAddresses: ['wss://relay.walletconnect.com'],
     walletAddress: 'https://wallet.multiversx.com',
     iframeWalletAddress: 'https://snap-wallet.multiversx.com',
     xAliasAddress: 'https://xalias.com',

--- a/src/constants/walletConnect.constants.ts
+++ b/src/constants/walletConnect.constants.ts
@@ -1,0 +1,8 @@
+import { WalletConnectConfig } from 'core/providers';
+
+export const fallbackWalletConnectConfigurations: WalletConnectConfig = {
+  walletConnectV2ProjectId: '',
+  walletConnectDeepLink:
+    'https://maiar.page.link/?apn=com.elrond.maiar.wallet&isi=1519405832&ibi=com.elrond.maiar.wallet&link=https://xportal.com/',
+  walletConnectV2RelayAddress: 'wss://relay.walletconnect.com'
+};

--- a/src/core/providers/strategies/WalletConnectProviderStrategy/WalletConnectProviderStrategy.ts
+++ b/src/core/providers/strategies/WalletConnectProviderStrategy/WalletConnectProviderStrategy.ts
@@ -185,8 +185,7 @@ export class WalletConnectProviderStrategy {
 
     const handleOnLogin = () => {};
 
-    const handleOnLogout = async () => {
-      await config.onLogout?.();
+    const handleOnLogout = () => {
       logoutAction();
     };
 

--- a/src/core/providers/strategies/WalletConnectProviderStrategy/types/walletConnect.types.ts
+++ b/src/core/providers/strategies/WalletConnectProviderStrategy/types/walletConnect.types.ts
@@ -26,12 +26,8 @@ export interface IWalletConnectModalData {
 
 export interface WalletConnectConfig {
   walletConnectV2ProjectId: string;
-  /**
-   * Function to be called when disconnecting the dApp from xPortal.
-   * Handles user redirection or cleanup after logout.
-   */
-  onLogout: () => Promise<void>;
   walletConnectV2RelayAddress?: string;
   walletConnectV2Options?: WalletConnectV2ProviderOptionsType;
-  customRequestMethods?: Array<string>;
+  customRequestMethods?: string[];
+  walletConnectDeepLink?: string;
 }

--- a/src/store/actions/config/configActions.ts
+++ b/src/store/actions/config/configActions.ts
@@ -1,3 +1,4 @@
+import { fallbackWalletConnectConfigurations } from 'constants/walletConnect.constants';
 import { CrossWindowConfig } from 'core/providers/strategies/CrossWindowProviderStrategy/types';
 import { WalletConnectConfig } from 'core/providers/strategies/WalletConnectProviderStrategy/types';
 import { NativeAuthConfigType } from 'services/nativeAuth/nativeAuth.types';
@@ -11,7 +12,18 @@ export const setNativeAuthConfig = (config: NativeAuthConfigType) =>
 export const setWalletConnectConfig = (config: WalletConnectConfig) =>
   getStore().setState(
     ({ config: state }) => {
-      state.walletConnectConfig = config;
+      const walletConnectV2RelayAddress =
+        config.walletConnectV2RelayAddress ||
+        fallbackWalletConnectConfigurations.walletConnectV2RelayAddress;
+      const walletConnectDeepLink =
+        config.walletConnectDeepLink ||
+        fallbackWalletConnectConfigurations.walletConnectDeepLink;
+
+      state.walletConnectConfig = {
+        ...config,
+        walletConnectDeepLink,
+        walletConnectV2RelayAddress
+      };
     },
     false,
     'setWalletConnectConfig'

--- a/src/store/actions/network/initializeNetwork.ts
+++ b/src/store/actions/network/initializeNetwork.ts
@@ -2,7 +2,7 @@ import { getServerConfiguration } from 'apiCalls/configuration/getServerConfigur
 import { fallbackNetworkConfigurations } from 'constants/network.constants';
 import { emptyNetwork } from 'store/slices/network/emptyNetwork';
 import { EnvironmentsEnum } from 'types/enums.types';
-import { CustomNetworkType, NetworkType } from 'types/network.types';
+import { NetworkType, CustomNetworkType } from 'types/network.types';
 import { initializeNetworkConfig } from './networkActions';
 
 export type InitializeNetworkPropsType = {
@@ -32,12 +32,7 @@ export const initializeNetwork = async ({
 
   const localConfig: NetworkType = {
     ...baseConfig,
-    apiTimeout: String(baseConfig.apiTimeout),
-    walletConnectBridgeAddresses: baseConfig.walletConnectBridgeAddresses || [],
-    walletConnectV2RelayAddresses:
-      'walletConnectV2RelayAddresses' in baseConfig
-        ? baseConfig.walletConnectV2RelayAddresses
-        : ['wss://relay.walletconnect.com']
+    apiTimeout: String(baseConfig.apiTimeout)
   };
 
   const fallbackApiAddress = fallbackConfig?.apiAddress;

--- a/src/store/actions/network/networkActions.ts
+++ b/src/store/actions/network/networkActions.ts
@@ -4,30 +4,13 @@ import { getStore } from '../../store';
 export const initializeNetworkConfig = (newNetwork: NetworkType) =>
   getStore().setState(
     ({ network: state }) => {
-      const walletConnectV2RelayAddress =
-        newNetwork.walletConnectV2RelayAddresses[
-          Math.floor(
-            Math.random() * newNetwork.walletConnectV2RelayAddresses.length
-          )
-        ];
-
       state.network = {
         ...state.network,
-        ...newNetwork,
-        walletConnectV2RelayAddress
+        ...newNetwork
       };
     },
     false,
     'initializeNetworkConfig'
-  );
-
-export const setCustomWalletAddress = (customWalletAddress: string) =>
-  getStore().setState(
-    ({ network: state }) => {
-      state.network.customWalletAddress = customWalletAddress;
-    },
-    false,
-    'setCustomWalletAddress'
   );
 
 export { initializeNetwork } from './initializeNetwork';

--- a/src/store/slices/network/emptyNetwork.ts
+++ b/src/store/slices/network/emptyNetwork.ts
@@ -1,6 +1,6 @@
-import { CurrentNetworkType } from 'types/network.types';
+import { NetworkType } from 'types/network.types';
 
-export const emptyNetwork: CurrentNetworkType = {
+export const emptyNetwork: NetworkType = {
   id: 'not-configured',
   chainId: '',
   name: 'NOT CONFIGURED',
@@ -8,11 +8,6 @@ export const emptyNetwork: CurrentNetworkType = {
   decimals: '18',
   digits: '4',
   gasPerDataByte: '1500',
-  walletConnectDeepLink: '',
-  walletConnectBridgeAddress: '',
-  walletConnectV2RelayAddress: '',
-  walletConnectV2ProjectId: '',
-  walletConnectV2Options: {},
   walletAddress: '',
   apiAddress: '',
   explorerAddress: '',

--- a/src/store/slices/network/network.types.ts
+++ b/src/store/slices/network/network.types.ts
@@ -1,6 +1,6 @@
-import { CurrentNetworkType } from 'types/network.types';
+import { NetworkType } from 'types/network.types';
 
 export interface NetworkSliceType {
-  network: CurrentNetworkType;
+  network: NetworkType;
   customWalletAddress: string;
 }

--- a/src/store/slices/network/networkSlice.types.ts
+++ b/src/store/slices/network/networkSlice.types.ts
@@ -1,5 +1,5 @@
-import { CurrentNetworkType } from 'types/network.types';
+import { NetworkType } from 'types/network.types';
 
 export interface NetworkSliceType {
-  network: CurrentNetworkType;
+  network: NetworkType;
 }

--- a/src/types/network.types.ts
+++ b/src/types/network.types.ts
@@ -1,4 +1,4 @@
-export interface BaseNetworkType {
+export interface NetworkType {
   id: string;
   chainId: string;
   name: string;
@@ -6,50 +6,24 @@ export interface BaseNetworkType {
   decimals: string;
   digits: string;
   gasPerDataByte: string;
-  walletConnectDeepLink: string;
   walletAddress: string;
   apiAddress: string;
   explorerAddress: string;
   apiTimeout: string;
-  walletConnectV2ProjectId?: string;
-  walletConnectV2Options?: Record<string, any>;
   xAliasAddress?: string;
   roundDuration: number;
   iframeWalletAddress?: string;
   websocketUrl?: string;
 }
 
-export interface CurrentNetworkType extends BaseNetworkType {
-  walletConnectBridgeAddress: string;
-  walletConnectV2RelayAddress: string;
-  customWalletAddress?: string;
-}
-
-export interface NetworkType extends BaseNetworkType {
-  walletConnectBridgeAddresses: string[];
-  walletConnectV2RelayAddresses: string[];
-}
-
-export interface CustomNetworkType {
-  id?: string;
-  chainId?: string;
-  name?: string;
-  egldLabel?: string;
-  decimals?: string;
-  digits?: string;
-  gasPerDataByte?: string;
-  walletConnectDeepLink?: string;
-  walletConnectBridgeAddresses?: string[];
-  walletAddress?: string;
-  apiAddress?: string;
-  explorerAddress?: string;
+export type CustomNetworkType = {
+  [P in keyof NetworkType]?: NetworkType[P];
+} & {
+  /**
+   * If set to `true`, network configuration in init app will prevent a call to `dapp/config`.
+   */
   skipFetchFromServer?: boolean;
-  apiTimeout?: string;
-  walletConnectV2ProjectId?: string;
-  walletConnectV2Options?: any;
-  iframeWalletAddress?: string;
-  websocketUrl?: string;
-}
+};
 
 export interface ApiNetworkConfigType {
   erd_chain_id: string;


### PR DESCRIPTION
### Feature
Clean-up network configuration
- Move walletconnect configs to configSlice from networkSlice
- Remove CurrentNetworkType
- Remove BaseNetworkType
- simplify CustomNetworkType

### Additional changes
- remove customWalletAddress
- remove onLogout prop from configuring walletconnect provider

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
