### PR TITLE
Refactor track 

### DIFF
--- a/src/core/managers/TransactionManager/TransactionManager.ts
+++ b/src/core/managers/TransactionManager/TransactionManager.ts
@@ -74,7 +74,12 @@ export class TransactionManager {
       transactionsDisplayInfo?: TransactionsDisplayInfoType;
     } = { disableToasts: false }
   ): Promise<string> => {
-    const flatTransactions = this.sequentialToFlatArray(sentTransactions);
+    const flatTransactions = this.sequentialToFlatArray(sentTransactions).map(
+      (transaction) => ({
+        ...transaction,
+        status: transaction.status ?? TransactionServerStatusesEnum.pending
+      })
+    );
 
     const status = getTransactionsSessionStatus(flatTransactions);
 


### PR DESCRIPTION
### Feature
Allow users to track transactions without being logged in

### Root cause
Some transactions are sent by the server and users need to be able to track them without logging in

### Fix
Change the signed transaction type by making the status optional, but keeping the hash mandatory
Main body of the changes can be found [here](https://github.com/multiversx/mx-sdk-dapp-core/commit/154dc78367a8ae70ad35e3d7e6b3ff826cc68386)

### Additional changes
Include documentation

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
