### PR TITLE
Fix ledger reload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed ledger logout on page reload](https://github.com/multiversx/mx-sdk-dapp-core/pull/126)
 - [Fixed handling of array data in side panel manager](https://github.com/multiversx/mx-sdk-dapp-core/pull/125)
 - [Migrate modals to side panel](https://github.com/multiversx/mx-sdk-dapp-core/pull/122)
 

--- a/src/core/managers/NotificationsFeedManager/NotificationsFeedManager.ts
+++ b/src/core/managers/NotificationsFeedManager/NotificationsFeedManager.ts
@@ -129,8 +129,6 @@ export class NotificationsFeedManager extends SidePanelBaseManager<
       account
     });
 
-    console.log(112, this.data);
-
     this.data.pendingTransactions = pendingTransactions;
 
     this.data.historicTransactions =

--- a/src/core/managers/NotificationsFeedManager/NotificationsFeedManager.ts
+++ b/src/core/managers/NotificationsFeedManager/NotificationsFeedManager.ts
@@ -36,7 +36,8 @@ export class NotificationsFeedManager extends SidePanelBaseManager<
   }
 
   constructor() {
-    super();
+    super('notifications-feed');
+    this.data = { ...this.initialData };
   }
 
   public isNotificationsFeedOpen(): boolean {
@@ -127,6 +128,8 @@ export class NotificationsFeedManager extends SidePanelBaseManager<
       sessions,
       account
     });
+
+    console.log(112, this.data);
 
     this.data.pendingTransactions = pendingTransactions;
 

--- a/src/core/managers/SidePanelBaseManager/SidePanelBaseManager.ts
+++ b/src/core/managers/SidePanelBaseManager/SidePanelBaseManager.ts
@@ -13,11 +13,13 @@ export abstract class SidePanelBaseManager<TElement, TData, TEventEnum> {
   protected isCreatingElement = false;
   protected isOpen = false;
   protected anchor?: HTMLElement;
+  protected type?: string; // useful for debugging
 
   protected abstract initialData: TData;
   protected data: TData;
 
-  constructor() {
+  constructor(type?: string) {
+    this.type = type;
     this.data = this.getInitialData();
   }
 

--- a/src/core/managers/internal/LedgerConnectStateManager/LedgerConnectStateManager.ts
+++ b/src/core/managers/internal/LedgerConnectStateManager/LedgerConnectStateManager.ts
@@ -63,7 +63,7 @@ export class LedgerConnectStateManager extends SidePanelBaseManager<
   };
 
   constructor() {
-    super();
+    super('ledger-connect');
     this.data = this.getInitialData();
   }
 

--- a/src/core/managers/internal/PendingTransactionsStateManager/PendingTransactionsStateManager.ts
+++ b/src/core/managers/internal/PendingTransactionsStateManager/PendingTransactionsStateManager.ts
@@ -30,7 +30,8 @@ export class PendingTransactionsStateManager extends SidePanelBaseManager<
   }
 
   constructor() {
-    super();
+    super('pending-transactions');
+    this.data = { ...this.initialData };
   }
 
   public isPendingTransactionsOpen(): boolean {

--- a/src/core/managers/internal/SignTransactionsStateManager/SignTransactionsStateManager.ts
+++ b/src/core/managers/internal/SignTransactionsStateManager/SignTransactionsStateManager.ts
@@ -51,7 +51,8 @@ export class SignTransactionsStateManager extends SidePanelBaseManager<
   }
 
   constructor() {
-    super();
+    super('sign-transactions');
+    this.data = { ...this.initialData };
   }
 
   public async init() {

--- a/src/core/managers/internal/WalletConnectStateManager/WalletConnectStateManager.ts
+++ b/src/core/managers/internal/WalletConnectStateManager/WalletConnectStateManager.ts
@@ -26,7 +26,8 @@ export class WalletConnectStateManager extends SidePanelBaseManager<
   }
 
   constructor() {
-    super();
+    super('wallet-connect');
+    this.data = { ...this.initialData };
   }
 
   public async openWalletConnect(data: IWalletConnectModalData) {

--- a/src/core/providers/strategies/LedgerProviderStrategy/LedgerProviderStrategy.ts
+++ b/src/core/providers/strategies/LedgerProviderStrategy/LedgerProviderStrategy.ts
@@ -48,7 +48,7 @@ export class LedgerProviderStrategy {
     const ledgerConnectManager = LedgerConnectStateManager.getInstance();
     const isLoggedIn = getIsLoggedIn();
 
-    const shouldOpenPanel = !options?.anchor; // TODO: check if this is correct
+    const shouldOpenPanel = !options?.anchor;
 
     if (shouldOpenPanel && !isLoggedIn) {
       await ledgerConnectManager.openLedgerConnect();

--- a/src/core/providers/strategies/LedgerProviderStrategy/LedgerProviderStrategy.ts
+++ b/src/core/providers/strategies/LedgerProviderStrategy/LedgerProviderStrategy.ts
@@ -3,11 +3,13 @@ import { IDAppProviderOptions } from '@multiversx/sdk-dapp-utils/out';
 import { HWProvider } from '@multiversx/sdk-hw-provider';
 import { safeWindow } from 'constants/index';
 
+import { CANCEL_TRANSACTION_TOAST_DEFAULT_DURATION } from 'constants/transactions.constants';
 import { LedgerConnectStateManager } from 'core/managers/internal/LedgerConnectStateManager/LedgerConnectStateManager';
 import { getAddress } from 'core/methods/account/getAddress';
 import { getIsLoggedIn } from 'core/methods/account/getIsLoggedIn';
 import { IProvider } from 'core/providers/types/providerFactory.types';
 import { defineCustomElements, IEventBus } from 'lib/sdkDappCoreUi';
+import { createCustomToast } from 'store/actions/toasts/toastsActions';
 import { ProviderErrorsEnum } from 'types/provider.types';
 import { getLedgerProvider } from './helpers';
 import { authenticateLedgerAccount } from './helpers/authenticateLedgerAccount';
@@ -44,8 +46,11 @@ export class LedgerProviderStrategy {
     await defineCustomElements(safeWindow);
     await this.createEventBus(options?.anchor);
     const ledgerConnectManager = LedgerConnectStateManager.getInstance();
+    const isLoggedIn = getIsLoggedIn();
 
-    if (!options?.anchor) {
+    const shouldOpenPanel = !options?.anchor; // TODO: check if this is correct
+
+    if (shouldOpenPanel && !isLoggedIn) {
       await ledgerConnectManager.openLedgerConnect();
     }
 
@@ -138,11 +143,7 @@ export class LedgerProviderStrategy {
       throw new Error(ProviderErrorsEnum.notInitialized);
     }
 
-    const isConnected = this.provider.isConnected();
-
-    if (!isConnected) {
-      throw new Error('Ledger device is not connected');
-    }
+    await this.rebuildProvider();
 
     const ledgerConnectManager = LedgerConnectStateManager.getInstance();
     await ledgerConnectManager.init();
@@ -169,11 +170,39 @@ export class LedgerProviderStrategy {
       throw new Error(ProviderErrorsEnum.notInitialized);
     }
 
+    await this.rebuildProvider();
+
     const signedMessage = await signLedgerMessage({
       message,
       handleSignMessage: this._signMessage.bind(this.provider)
     });
 
     return signedMessage;
+  };
+
+  private rebuildProvider = async () => {
+    try {
+      await this.provider?.getAddress(); // can communicate with device
+    } catch (_err) {
+      try {
+        const { ledgerProvider } = await getLedgerProvider({
+          shouldInitProvider: true
+        });
+        this.provider = ledgerProvider;
+        this._signTransactions =
+          ledgerProvider.signTransactions.bind(ledgerProvider);
+        this._signMessage = ledgerProvider.signMessage.bind(ledgerProvider);
+      } catch (error) {
+        createCustomToast({
+          toastId: 'ledger-provider-rebuild-error',
+          duration: CANCEL_TRANSACTION_TOAST_DEFAULT_DURATION,
+          icon: 'times',
+          iconClassName: 'warning',
+          message: 'Unlock your device & open the MultiversX App',
+          title: 'Ledger unavailable'
+        });
+        throw error;
+      }
+    }
   };
 }

--- a/src/core/providers/strategies/LedgerProviderStrategy/helpers/getLedgerProvider.ts
+++ b/src/core/providers/strategies/LedgerProviderStrategy/helpers/getLedgerProvider.ts
@@ -61,10 +61,6 @@ export async function getLedgerProvider(props?: {
   } catch (err) {
     console.error('Could not initialize ledger app', err);
 
-    // if (isLoggedIn) {
-    //   await provider.logout();
-    // }
-
     throw err;
   }
 }

--- a/src/core/providers/strategies/LedgerProviderStrategy/helpers/getLedgerProvider.ts
+++ b/src/core/providers/strategies/LedgerProviderStrategy/helpers/getLedgerProvider.ts
@@ -1,14 +1,21 @@
 import { HWProvider } from '@multiversx/sdk-hw-provider';
 import { getIsLoggedIn } from 'core/methods/account/getIsLoggedIn';
 import { getAccountProvider } from 'core/providers/helpers/accountProvider';
+import { ledgerAccountSelector } from 'store/selectors/accountSelectors';
 import { ledgerLoginSelector } from 'store/selectors/loginInfoSelectors';
 import { getState } from 'store/store';
 import { getLedgerConfiguration } from './getLedgerConfiguration';
 
-export async function getLedgerProvider() {
+export async function getLedgerProvider(props?: {
+  shouldInitProvider?: boolean; // provider will be initialized if not logged in
+}) {
   const isLoggedIn = getIsLoggedIn();
+  const shouldInitProvider = props?.shouldInitProvider || !isLoggedIn;
   const ledgerLogin = ledgerLoginSelector(getState());
+  const ledgerAccount = ledgerAccountSelector(getState());
   const provider = getAccountProvider();
+
+  const ledgerProvider = new HWProvider();
 
   const initHWProvider = async () => {
     const hasAddressIndex = ledgerLogin?.index != null;
@@ -21,11 +28,11 @@ export async function getLedgerProvider() {
       return provider;
     }
 
-    const ledgerProvider = new HWProvider();
-    const isInitialized = await ledgerProvider.init();
-
-    if (!isInitialized) {
-      throw new Error('Failed to initialize Ledger Provider');
+    if (shouldInitProvider) {
+      const isInitialized = await ledgerProvider.init();
+      if (!isInitialized) {
+        throw new Error('Failed to initialize Ledger Provider');
+      }
     }
 
     if (hasAddressIndex) {
@@ -36,15 +43,27 @@ export async function getLedgerProvider() {
   };
 
   try {
-    const ledgerProvider = await initHWProvider();
-    const ledgerConfig = await getLedgerConfiguration(ledgerProvider);
-    return { ledgerProvider, ledgerConfig };
+    if (!shouldInitProvider && ledgerAccount) {
+      return {
+        ledgerProvider,
+        ledgerConfig: {
+          version: ledgerAccount.version,
+          dataEnabled: ledgerAccount.hasContractDataEnabled
+        }
+      };
+    }
+
+    const initializedLedgerProvider = await initHWProvider();
+    const ledgerConfig = await getLedgerConfiguration(
+      initializedLedgerProvider
+    );
+    return { ledgerProvider: initializedLedgerProvider, ledgerConfig };
   } catch (err) {
     console.error('Could not initialize ledger app', err);
 
-    if (isLoggedIn) {
-      await provider.logout();
-    }
+    // if (isLoggedIn) {
+    //   await provider.logout();
+    // }
 
     throw err;
   }

--- a/src/store/selectors/accountSelectors.ts
+++ b/src/store/selectors/accountSelectors.ts
@@ -30,3 +30,7 @@ export const isLoggedInSelector = (store: StoreType) => {
   const account = accountSelector(store);
   return Boolean(address && account?.address === address);
 };
+
+export const ledgerAccountSelector = ({
+  account: { ledgerAccount }
+}: StoreType) => ledgerAccount;


### PR DESCRIPTION
### Issue
Refreshing the page after ledger login triggers provider logout

### Root cause
Initiating a provider must return an actual provider and if ledger communication is impossible it logs the user out

### Fix
Skip initiating ledger provider on page reload / provider reconstruction
Make signing methods refetch the provider before signing

### Additional changes
Added State Manager types for debugging


### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
