### PR TITLE
Fixed toasts completion and notifications feed toasts management

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed toasts completion management](https://github.com/multiversx/mx-sdk-dapp-core/pull/131)
 - [Toasts data refactoring](https://github.com/multiversx/mx-sdk-dapp-core/pull/129)
 - [Added ledger idle connection manager](https://github.com/multiversx/mx-sdk-dapp-core/pull/127)
 - [Fixed ledger logout on page reload](https://github.com/multiversx/mx-sdk-dapp-core/pull/126)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- [Fixed toasts completion management](https://github.com/multiversx/mx-sdk-dapp-core/pull/131)
+- [Fixed toasts completion and notifications feed toasts management](https://github.com/multiversx/mx-sdk-dapp-core/pull/131)
 - [Toasts data refactoring](https://github.com/multiversx/mx-sdk-dapp-core/pull/129)
 - [Added ledger idle connection manager](https://github.com/multiversx/mx-sdk-dapp-core/pull/127)
 - [Fixed ledger logout on page reload](https://github.com/multiversx/mx-sdk-dapp-core/pull/126)

--- a/src/core/managers/NotificationsFeedManager/NotificationsFeedManager.ts
+++ b/src/core/managers/NotificationsFeedManager/NotificationsFeedManager.ts
@@ -22,6 +22,7 @@ export class NotificationsFeedManager extends SidePanelBaseManager<
   private static instance: NotificationsFeedManager;
   private store = getStore();
   private storeToastsUnsubscribe: () => void = () => null;
+  private eventBusUnsubscribeFunctions: (() => void)[] = [];
 
   protected initialData: INotificationsFeedManagerData = {
     pendingTransactions: [],
@@ -72,6 +73,8 @@ export class NotificationsFeedManager extends SidePanelBaseManager<
 
   public destroy() {
     this.storeToastsUnsubscribe();
+    this.eventBusUnsubscribeFunctions.forEach((unsubscribe) => unsubscribe());
+    this.eventBusUnsubscribeFunctions = [];
     super.destroy();
   }
 
@@ -105,10 +108,24 @@ export class NotificationsFeedManager extends SidePanelBaseManager<
       this.handleCloseUI.bind(this)
     );
 
+    this.eventBusUnsubscribeFunctions.push(() => {
+      this.eventBus?.unsubscribe(
+        NotificationsFeedEventsEnum.CLOSE_NOTIFICATIONS_FEED,
+        this.handleCloseUI.bind(this)
+      );
+    });
+
     this.eventBus.subscribe(
       NotificationsFeedEventsEnum.CLEAR_NOTIFICATIONS_FEED_HISTORY,
       this.handleClearNotificationsFeedHistory.bind(this)
     );
+
+    this.eventBusUnsubscribeFunctions.push(() => {
+      this.eventBus?.unsubscribe(
+        NotificationsFeedEventsEnum.CLEAR_NOTIFICATIONS_FEED_HISTORY,
+        this.handleClearNotificationsFeedHistory.bind(this)
+      );
+    });
   }
 
   private handleClearNotificationsFeedHistory() {

--- a/src/core/managers/TransactionManager/TransactionManager.ts
+++ b/src/core/managers/TransactionManager/TransactionManager.ts
@@ -23,8 +23,6 @@ import { isBatchTransaction } from './helpers/isBatchTransaction';
 export class TransactionManager {
   private static instance: TransactionManager | null = null;
 
-  constructor() {}
-
   public static getInstance(): TransactionManager {
     if (!TransactionManager.instance) {
       TransactionManager.instance = new TransactionManager();
@@ -94,7 +92,11 @@ export class TransactionManager {
     }
 
     const totalDuration = getToastDuration(sentTransactions);
-    addTransactionToast({ toastId: sessionId, totalDuration });
+    addTransactionToast({
+      toastId: sessionId,
+      totalDuration
+    });
+
     return sessionId;
   };
 

--- a/src/core/methods/initApp/initApp.ts
+++ b/src/core/methods/initApp/initApp.ts
@@ -84,7 +84,7 @@ export async function initApp({
     successfulToastLifetime: dAppConfig.successfulToastLifetime
   });
 
-  toastManager.init();
+  await toastManager.init();
 
   const pendingTransactionsStateManager =
     PendingTransactionsStateManager.getInstance();

--- a/src/store/actions/toasts/toastsActions.ts
+++ b/src/store/actions/toasts/toastsActions.ts
@@ -71,6 +71,12 @@ export const removeAllCustomToasts = () => {
   );
 };
 
+export const removeAllTransactionToasts = () => {
+  getStore().setState(({ toasts: state }) => {
+    state.transactionToasts = [];
+  });
+};
+
 export const addTransactionToast = ({
   toastId,
   totalDuration


### PR DESCRIPTION
### Issue
- Completed toasts are not shown, they disappear instantly after no longer in pending state;
- Closing of notification feed does not show toasts back.

### Fix
- Refactor LifeTimeManager;
- Refactor publishing and mapping of transaction toasts in ToastsManager;
- Subscribe to correct eventBus (of NotificationsFeedManager) in ToastsManager.

### Additional changes
- Add unsubscribe of eventBus subscriptions on destroy in ToastsManager and in NotificationsFeedManager

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
