### PR TITLE
Initialize dappProvider with null

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fix DappProvider init in NextJS](https://github.com/multiversx/mx-sdk-dapp-core/pull/134)
 - [Updated prefix to ui tags and component imports](https://github.com/multiversx/mx-sdk-dapp-core/pull/133)
 
 ## [[0.0.0-alpha.17](https://github.com/multiversx/mx-sdk-dapp-core/pull/124)] - 2025-03-31

--- a/src/core/providers/helpers/accountProvider.ts
+++ b/src/core/providers/helpers/accountProvider.ts
@@ -4,7 +4,7 @@ import { emptyProvider } from './emptyProvider';
 
 export type ProvidersType = IProvider;
 
-let accountProvider: DappProvider = new DappProvider(emptyProvider);
+let accountProvider: DappProvider | null = null;
 
 export function setAccountProvider<TProvider extends DappProvider>(
   provider: TProvider
@@ -13,5 +13,5 @@ export function setAccountProvider<TProvider extends DappProvider>(
 }
 
 export function getAccountProvider(): DappProvider {
-  return (accountProvider as DappProvider) || emptyProvider;
+  return accountProvider || new DappProvider(emptyProvider);
 }


### PR DESCRIPTION
### Issue
DappProvider is not recognized as a constructor in NextJS

<img width="970" alt="image" src="https://github.com/user-attachments/assets/1477fd31-0073-4429-b49a-a02161949766" />

### Reproduce
Issue exists on version `0.0.0-alpha.17` of sdk-dapp.

### Root cause

### Fix
Init with null instead of new DappProvider(emptyProvider)

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
