### PR TITLE
Parallelize managers on init

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Add parallel manager initialization](https://github.com/multiversx/mx-sdk-dapp-core/pull/136)
+
 ## [[0.0.0-alpha.18](https://github.com/multiversx/mx-sdk-dapp-core/pull/135)] - 2025-04-09
+
 - [Fix DappProvider init in NextJS](https://github.com/multiversx/mx-sdk-dapp-core/pull/134)
 - [Updated prefix to ui tags and component imports](https://github.com/multiversx/mx-sdk-dapp-core/pull/133)
 

--- a/src/core/methods/initApp/initApp.ts
+++ b/src/core/methods/initApp/initApp.ts
@@ -84,15 +84,17 @@ export async function initApp({
     successfulToastLifetime: dAppConfig.successfulToastLifetime
   });
 
-  await toastManager.init();
-
   const pendingTransactionsStateManager =
     PendingTransactionsStateManager.getInstance();
-  await pendingTransactionsStateManager.init();
 
   const signTransactionsStateManager =
     SignTransactionsStateManager.getInstance();
-  await signTransactionsStateManager.init();
+
+  await Promise.all([
+    toastManager.init(),
+    pendingTransactionsStateManager.init(),
+    signTransactionsStateManager.init()
+  ]);
 
   const usedProviders = [
     ...((safeWindow as any)?.multiversx?.providers || []),


### PR DESCRIPTION
### Issue
Duration increased for each manager initialization

### Reproduce
Issue exists on version `0.0.0-alpha.18` of sdk-dapp-core.

### Root cause
Going through every manager in oder to init.

### Fix
Parallelize initialization of managers.

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
