### PR TITLE
Publish fixes

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -33,7 +33,7 @@ jobs:
         run: yarn test
 
       - name: Build project
-        run: yarn compile
+        run: yarn build
 
       - name: Get package info
         id: package

--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -18,6 +18,8 @@ jobs:
       packages: write
     steps:
       - uses: actions/checkout@v3
+        with:
+          ref: ${{ github.ref }}
       - uses: actions/setup-node@v1
         with:
           node-version: 18

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Switched publish workflow to esbuild](https://github.com/multiversx/mx-sdk-dapp-core/pull/137)
 - [Add parallel manager initialization](https://github.com/multiversx/mx-sdk-dapp-core/pull/136)
 
 ## [[0.0.0-alpha.18](https://github.com/multiversx/mx-sdk-dapp-core/pull/135)] - 2025-04-09

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@multiversx/sdk-dapp-core",
-  "version": "0.0.0-alpha.18",
+  "version": "0.0.0-alpha.19",
   "main": "out/index.js",
   "module": "out/index.mjs",
   "types": "out/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "@multiversx/sdk-dapp-core",
   "version": "0.0.0-alpha.18",
   "main": "out/index.js",
-  "module": "out/index.js",
+  "module": "out/index.mjs",
   "types": "out/index.d.ts",
   "description": "A library to hold core logic for building TypeScript dApps on the MultiversX blockchain",
   "author": "MultiversX",
@@ -20,13 +20,12 @@
   },
   "scripts": {
     "unpublish-verdaccio": "npm unpublish @multiversx/sdk-dapp-core --force --registry http://localhost:4873",
-    "publish-verdaccio": "npm run unpublish-verdaccio && npm run compile-next && npm publish --registry http://localhost:4873/",
+    "publish-verdaccio": "npm run unpublish-verdaccio && npm run build && npm publish --registry http://localhost:4873/",
     "compile": "tsc && tsc-alias",
     "build-esbuild": "rimraf out && node esbuild.js",
     "build": "yarn build-esbuild && yarn compile",
     "test": "jest",
-    "lint": "eslint --fix src",
-    "compile-next": "rimraf out && tsc --p tsconfig.next.json && tsc-alias --project tsconfig.next.json"
+    "lint": "eslint --fix src"
   },
   "publishConfig": {
     "access": "public"

--- a/tsconfig.next.json
+++ b/tsconfig.next.json
@@ -1,8 +1,0 @@
-{
-    "extends": "./tsconfig.json",
-    "compilerOptions": {
-        "module": "esnext",
-        "target": "ESNext",
-        "moduleResolution": "Node",
-    },
-  }


### PR DESCRIPTION
### Issue
Current workflow target is `CommonJS` which does not work when used with webcomponents inside `initApp`.

### Reproduce
Issue exists on version `0.0.0-alpha.18` of sdk-dapp-core.

### Root cause
Target is `CommonJS` instead of `es2021` or `esnext`

### Fix
Update workflow to use `esbuild` with target of `es2021`.

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
