### PR TITLE
Multiple instances

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Prevent multiple initApp executions](https://github.com/multiversx/mx-sdk-dapp-core/pull/138)
+
+## [[0.0.0-alpha.19](https://github.com/multiversx/mx-sdk-dapp-core/pull/137)] - 2025-04-10
+
 - [Switched publish workflow to esbuild](https://github.com/multiversx/mx-sdk-dapp-core/pull/137)
 - [Add parallel manager initialization](https://github.com/multiversx/mx-sdk-dapp-core/pull/136)
 

--- a/src/core/managers/SidePanelBaseManager/SidePanelBaseManager.ts
+++ b/src/core/managers/SidePanelBaseManager/SidePanelBaseManager.ts
@@ -99,12 +99,10 @@ export abstract class SidePanelBaseManager<TElement, TData, TEventEnum> {
       throw new Error(`Failed to create ${this.getUIElementName()} element`);
     }
 
-    if (!this.eventBus) {
-      // Try to get the event bus from the UI element again
-      this.eventBus = await (
-        this.uiElement as unknown as IUIElement
-      ).getEventBus();
-    }
+    // Try to get the event bus from the UI element again
+    this.eventBus ??= await (
+      this.uiElement as unknown as IUIElement
+    ).getEventBus();
 
     if (!this.eventBus) {
       // The event bus failed to be retrieved
@@ -114,7 +112,9 @@ export abstract class SidePanelBaseManager<TElement, TData, TEventEnum> {
     return this.eventBus;
   }
 
-  public async createUIElement(anchor?: HTMLElement): Promise<TElement | null> {
+  public async createUIElement(
+    anchor: HTMLElement | undefined = this.anchor
+  ): Promise<TElement | null> {
     if (this.isCreatingElement || this.uiElement) {
       return this.uiElement;
     }

--- a/src/core/managers/SidePanelBaseManager/SidePanelBaseManager.ts
+++ b/src/core/managers/SidePanelBaseManager/SidePanelBaseManager.ts
@@ -99,7 +99,6 @@ export abstract class SidePanelBaseManager<TElement, TData, TEventEnum> {
       throw new Error(`Failed to create ${this.getUIElementName()} element`);
     }
 
-    // Try to get the event bus from the UI element again
     this.eventBus ??= await (
       this.uiElement as unknown as IUIElement
     ).getEventBus();

--- a/src/core/managers/SidePanelBaseManager/SidePanelBaseManager.ts
+++ b/src/core/managers/SidePanelBaseManager/SidePanelBaseManager.ts
@@ -84,6 +84,11 @@ export abstract class SidePanelBaseManager<TElement, TData, TEventEnum> {
   }
 
   public async getEventBus(): Promise<IEventBus | null> {
+    // Return eventBus in null state while element is being created
+    if (this.isCreatingElement) {
+      return this.eventBus;
+    }
+
     if (!this.uiElement) {
       // Try to create the UI element again
       await this.createUIElement();
@@ -109,21 +114,18 @@ export abstract class SidePanelBaseManager<TElement, TData, TEventEnum> {
     return this.eventBus;
   }
 
-  public async createUIElement(
-    anchor: HTMLElement | undefined = this.anchor
-  ): Promise<TElement | null> {
-    if (this.uiElement) {
+  public async createUIElement(anchor?: HTMLElement): Promise<TElement | null> {
+    if (this.isCreatingElement || this.uiElement) {
       return this.uiElement;
     }
 
     if (!this.isCreatingElement) {
       this.isCreatingElement = true;
 
-      const options = anchor
-        ? { name: this.getUIElementName(), anchor }
-        : { name: this.getUIElementName() };
-
-      const element = await createUIElement<TElement>(options);
+      const element = await createUIElement<TElement>({
+        name: this.getUIElementName(),
+        anchor
+      });
 
       this.uiElement = element || null;
       await this.getEventBus();

--- a/src/core/managers/internal/ToastManager/ToastManager.ts
+++ b/src/core/managers/internal/ToastManager/ToastManager.ts
@@ -33,6 +33,7 @@ interface IToastManager {
 export class ToastManager {
   private lifetimeManager: LifetimeManager;
   private isCreatingElement = false;
+  private static instance: ToastManager;
   private toastsElement: MvxToastList | null = null;
   private transactionToasts: ITransactionToast[] = [];
   private customToasts: CustomToastType[] = [];
@@ -79,6 +80,13 @@ export class ToastManager {
         }
       }
     );
+  }
+
+  public static getInstance(config?: IToastManager): ToastManager {
+    if (!ToastManager.instance) {
+      ToastManager.instance = new ToastManager(config);
+    }
+    return ToastManager.instance;
   }
 
   private handleCompletedTransaction(toastId: string): boolean {

--- a/src/core/methods/initApp/initApp.ts
+++ b/src/core/methods/initApp/initApp.ts
@@ -97,7 +97,7 @@ export async function initApp({
   ]);
 
   const usedProviders = [
-    ...((safeWindow as any)?.multiversx?.providers || []),
+    ...((safeWindow as any)?.multiversx?.providers ?? []),
     ...(customProviders || [])
   ];
 

--- a/src/core/methods/initApp/initApp.ts
+++ b/src/core/methods/initApp/initApp.ts
@@ -80,7 +80,7 @@ export async function initApp({
     await login(provider.getProvider());
   }
 
-  const toastManager = new ToastManager({
+  const toastManager = ToastManager.getInstance({
     successfulToastLifetime: dAppConfig.successfulToastLifetime
   });
 


### PR DESCRIPTION
### Issue
initApp executed multiple times due to React's StrictMode, which triggers components to mount/unmount twice in development. This causes race conditions such as:
- multiple toast-list elements appearing in the DOM
- errors when elements are expected to exist but are still being created

### Reproduce
Issue exists on version `0.0.0-alpha.19` of sdk-dapp-core.

### Root cause
the SDK’s logic does not guard against multiple initializations, leading to duplicated elements and race conditions.

### Fix
add an internal guard inside to prevent multiple executions 

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
