### PR TITLE
Fix isssues with websocket and polling on init

### DIFF
--- a/src/constants/storage.constants.ts
+++ b/src/constants/storage.constants.ts
@@ -12,3 +12,5 @@ export const storage = safeWindow
       () => safeWindow[persistConfig.persistReducersStorageType]
     )
   : undefined;
+
+export const subscriptions = new Map<string, () => void>();

--- a/src/core/managers/internal/ToastManager/helpers/tests/createToastsFromTransactions.test.ts
+++ b/src/core/managers/internal/ToastManager/helpers/tests/createToastsFromTransactions.test.ts
@@ -1,4 +1,5 @@
 import { testAddress } from '__mocks__';
+import { WebsocketConnectionStatusEnum } from 'core/methods/initApp/websocket/websocket.constants';
 import {
   getIsTransactionPending,
   getIsTransactionSuccessful
@@ -59,6 +60,7 @@ describe('createToastsFromTransactions', () => {
     address: testAddress,
     accounts: {},
     publicKey: '',
+    websocketStatus: WebsocketConnectionStatusEnum.NOT_INITIALIZED,
     ledgerAccount: null,
     walletConnectAccount: null,
     websocketEvent: null,

--- a/src/core/methods/initApp/websocket/initializeWebsocketConnection.ts
+++ b/src/core/methods/initApp/websocket/initializeWebsocketConnection.ts
@@ -1,7 +1,7 @@
 import { io } from 'socket.io-client';
 import { getWebsocketUrl } from 'apiCalls/websocket';
-import { getAccount } from 'core/methods/account/getAccount';
 import {
+  setWebsocketStatus,
   setWebsocketBatchEvent,
   setWebsocketEvent
 } from 'store/actions/account/accountActions';
@@ -18,6 +18,7 @@ const TIMEOUT = 3000;
 const RECONNECTION_ATTEMPTS = 3;
 const RETRY_INTERVAL = 500;
 const MESSAGE_DELAY = 1000;
+const SOCKET_CONNECTION_DELAY = 1000;
 const BATCH_UPDATED_EVENT = 'batchUpdated';
 const CONNECT = 'connect';
 const CONNECT_ERROR = 'connect_error';
@@ -26,14 +27,23 @@ const DISCONNECT = 'disconnect';
 // eslint-disable-next-line no-undef
 type TimeoutType = NodeJS.Timeout | null;
 
-export async function initializeWebsocketConnection() {
-  const { address } = getAccount();
+export async function initializeWebsocketConnection(address: string) {
   const { apiAddress, websocketUrl: customWebsocketUrl } = networkSelector(
     getStore().getState()
   );
 
+  if (!address) {
+    throw new Error('Websocket could not be initialized: address missing');
+  }
+
   let messageTimeout: TimeoutType = null;
   let batchTimeout: TimeoutType = null;
+
+  // Update socket status in store for status subscription
+  const updateSocketStatus = (status: WebsocketConnectionStatusEnum) => {
+    websocketConnection.status = status;
+    setWebsocketStatus(status);
+  };
 
   const handleMessageReceived = (message: string) => {
     if (messageTimeout) {
@@ -53,25 +63,62 @@ export async function initializeWebsocketConnection() {
     }, MESSAGE_DELAY);
   };
 
-  const retryWebsocketConnect = () => {
-    setTimeout(() => {
-      if (address) {
-        console.log('Websocket reconnecting...');
-        websocketConnection.status = WebsocketConnectionStatusEnum.PENDING;
-        websocketConnection.instance?.connect();
+  // Retry mechanism for websocket connection
+  const retryWebsocketConnect = async (
+    retries = RECONNECTION_ATTEMPTS,
+    delay = RETRY_INTERVAL
+  ) => {
+    let attempt = 0;
+
+    const tryReconnect = async () => {
+      if (attempt >= retries) {
+        console.warn('WebSocket reconnection failed after max attempts.');
+        updateSocketStatus(WebsocketConnectionStatusEnum.NOT_INITIALIZED);
+        return;
       }
-    }, RETRY_INTERVAL);
+
+      attempt++;
+      console.log(`WebSocket reconnect attempt ${attempt}/${retries}...`);
+
+      // Clean up previous socket
+      websocketConnection.instance?.off();
+      websocketConnection.instance?.close();
+      websocketConnection.instance = null;
+
+      try {
+        // eslint-disable-next-line @typescript-eslint/no-use-before-define
+        await initializeConnection(); // attempt to reconnect
+
+        // Wait briefly and check if socket is actually connected
+        setTimeout(() => {
+          const isConnected = websocketConnection.instance?.connected;
+
+          if (!isConnected) {
+            console.warn('WebSocket not connected. Retrying...');
+            setTimeout(tryReconnect, delay);
+          }
+        }, SOCKET_CONNECTION_DELAY);
+      } catch (error) {
+        console.warn('Reconnect threw an error. Retrying...', error);
+        setTimeout(tryReconnect, delay);
+      }
+    };
+
+    tryReconnect();
   };
 
   const closeConnection = () => {
-    if (websocketConnection.instance) {
-      websocketConnection.instance.off(CONNECT_ERROR);
-      websocketConnection.instance.off(CONNECT);
-      websocketConnection.instance.off(BATCH_UPDATED_EVENT);
-      websocketConnection.instance.close();
+    const instance = websocketConnection.instance;
+    if (instance) {
+      instance.off(CONNECT_ERROR);
+      instance.off(CONNECT);
+      instance.off(BATCH_UPDATED_EVENT);
+      instance.off(DISCONNECT);
+      instance.close();
+      console.log('Websocket disconnected.');
     }
 
-    websocketConnection.status = WebsocketConnectionStatusEnum.NOT_INITIALIZED;
+    updateSocketStatus(WebsocketConnectionStatusEnum.NOT_INITIALIZED);
     websocketConnection.instance = null;
 
     if (messageTimeout) {
@@ -85,22 +132,16 @@ export async function initializeWebsocketConnection() {
 
   const initializeConnection = retryMultipleTimes(
     async () => {
-      if (!address) {
-        websocketConnection.status =
-          WebsocketConnectionStatusEnum.NOT_INITIALIZED;
-        return;
-      }
-
       // To avoid multiple connections to the same endpoint
-      websocketConnection.status = WebsocketConnectionStatusEnum.PENDING;
+      updateSocketStatus(WebsocketConnectionStatusEnum.PENDING);
 
       const websocketUrl =
         customWebsocketUrl ?? (await getWebsocketUrl(apiAddress));
 
       if (!websocketUrl) {
         console.warn('Cannot get websocket URL');
-        websocketConnection.status =
-          WebsocketConnectionStatusEnum.NOT_INITIALIZED;
+        updateSocketStatus(WebsocketConnectionStatusEnum.NOT_INITIALIZED);
+
         return;
       }
 
@@ -118,35 +159,23 @@ export async function initializeWebsocketConnection() {
 
       websocketConnection.instance.on(CONNECT, () => {
         console.log('Websocket connected.');
-        websocketConnection.status = WebsocketConnectionStatusEnum.COMPLETED;
+        updateSocketStatus(WebsocketConnectionStatusEnum.COMPLETED);
       });
 
       websocketConnection.instance.on(CONNECT_ERROR, (error) => {
         console.warn('Websocket connect error: ', error.message);
-
-        if (address) {
-          retryWebsocketConnect();
-        } else {
-          websocketConnection.status =
-            WebsocketConnectionStatusEnum.NOT_INITIALIZED;
-        }
+        retryWebsocketConnect();
       });
 
       websocketConnection.instance.on(DISCONNECT, () => {
-        if (address) {
-          console.warn('Websocket disconnected. Trying to reconnect...');
-          retryWebsocketConnect();
-        } else {
-          websocketConnection.status =
-            WebsocketConnectionStatusEnum.NOT_INITIALIZED;
-        }
+        console.warn('Websocket disconnected. Trying to reconnect...');
+        retryWebsocketConnect();
       });
     },
     { retries: 2, delay: RETRY_INTERVAL }
   );
 
   if (
-    address &&
     websocketConnection.status ===
       WebsocketConnectionStatusEnum.NOT_INITIALIZED &&
     !websocketConnection.instance?.active

--- a/src/core/methods/initApp/websocket/registerWebsocket.ts
+++ b/src/core/methods/initApp/websocket/registerWebsocket.ts
@@ -1,25 +1,10 @@
-import { getAccount } from 'core/methods/account/getAccount';
-import { getStore } from 'store/store';
 import { initializeWebsocketConnection } from './initializeWebsocketConnection';
 
-let localAddress = '';
-let closeConnectionRef: () => void;
+// Execute on logout in order to close the connection
+export let closeConnectionRef: () => void;
 
-export async function registerWebsocketListener() {
-  const store = getStore();
-  const account = getAccount();
-  localAddress = account.address;
+export async function registerWebsocketListener(address: string) {
+  const { closeConnection } = await initializeWebsocketConnection(address);
 
-  // Initialize the websocket connection
-  const data = await initializeWebsocketConnection();
-  closeConnectionRef = data.closeConnection;
-
-  store.subscribe(async ({ account: { address } }) => {
-    if (localAddress && address !== localAddress) {
-      closeConnectionRef();
-      localAddress = address;
-      const { closeConnection } = await initializeWebsocketConnection();
-      closeConnectionRef = closeConnection;
-    }
-  });
+  closeConnectionRef = closeConnection;
 }

--- a/src/core/methods/trackTransactions/trackTransactions.ts
+++ b/src/core/methods/trackTransactions/trackTransactions.ts
@@ -1,5 +1,7 @@
+import { subscriptions } from 'constants/storage.constants';
 import { websocketEventSelector } from 'store/selectors/accountSelectors';
 import { getStore } from 'store/store';
+import { SubscriptionsEnum } from 'types/subscriptions.type';
 import { checkTransactionStatus } from './helpers/checkTransactionStatus';
 import { getPollingInterval } from './helpers/getPollingInterval';
 import {
@@ -16,44 +18,109 @@ export async function trackTransactions() {
   const pollingInterval = getPollingInterval();
   // eslint-disable-next-line no-undef
   let pollingIntervalTimer: NodeJS.Timeout | null = null;
+  // eslint-disable-next-line no-undef
+  let websocketStatusCheckTimer: NodeJS.Timeout | null = null;
   let timestamp = websocketEventSelector(store.getState())?.timestamp;
-
-  const isWebsocketCompleted =
-    websocketConnection.status === WebsocketConnectionStatusEnum.COMPLETED;
 
   const recheckStatus = () => {
     checkTransactionStatus();
   };
 
-  recheckStatus();
-
-  if (isWebsocketCompleted) {
-    // Do not set polling interval if websocket is complete
-    if (pollingIntervalTimer) {
-      clearInterval(pollingIntervalTimer);
-      pollingIntervalTimer = null;
-    }
-    store.subscribe(async ({ account: { websocketEvent } }) => {
-      if (websocketEvent?.message && timestamp !== websocketEvent.timestamp) {
-        timestamp = websocketEvent.timestamp;
-        recheckStatus();
-      }
-    });
-  } else {
-    // Set polling interval if websocket is not complete and no existing interval is set
+  const startPolling = () => {
     if (!pollingIntervalTimer) {
       pollingIntervalTimer = setInterval(recheckStatus, pollingInterval);
     }
-  }
+  };
 
-  function cleanup() {
+  const stopPolling = () => {
     if (pollingIntervalTimer) {
       clearInterval(pollingIntervalTimer);
       pollingIntervalTimer = null;
     }
+  };
+
+  const setupWebSocketTracking = () => {
+    stopPolling();
+    const unsubscribeWebsocketEvent = store.subscribe(
+      ({ account: { websocketEvent } }) => {
+        if (websocketEvent?.message && timestamp !== websocketEvent.timestamp) {
+          timestamp = websocketEvent.timestamp;
+          recheckStatus();
+        }
+      }
+    );
+
+    subscriptions.set(
+      SubscriptionsEnum.websocketEvent,
+      unsubscribeWebsocketEvent
+    );
+  };
+
+  const startWatchingWebsocketStatus = () => {
+    if (
+      websocketConnection.status !==
+        WebsocketConnectionStatusEnum.NOT_INITIALIZED ||
+      websocketStatusCheckTimer
+    ) {
+      return;
+    }
+
+    websocketStatusCheckTimer = setInterval(() => {
+      if (
+        websocketConnection.status === WebsocketConnectionStatusEnum.COMPLETED
+      ) {
+        clearInterval(websocketStatusCheckTimer!);
+        websocketStatusCheckTimer = null;
+        setupWebSocketTracking();
+      }
+    }, 1000);
+  };
+
+  // Initial execution
+  recheckStatus();
+
+  function cleanup() {
+    stopPolling();
+    if (websocketStatusCheckTimer) {
+      clearInterval(websocketStatusCheckTimer);
+      websocketStatusCheckTimer = null;
+    }
   }
 
-  return {
-    cleanup
-  };
+  const unsubscribeWebsocketStatus = store.subscribe(
+    ({ account: { websocketStatus, address } }, prevState) => {
+      const hasStatusChange =
+        prevState.account.websocketStatus !== websocketStatus;
+
+      if (!hasStatusChange) {
+        return;
+      }
+
+      switch (websocketStatus) {
+        case WebsocketConnectionStatusEnum.COMPLETED:
+          setupWebSocketTracking();
+          break;
+        case WebsocketConnectionStatusEnum.PENDING:
+          startPolling();
+          startWatchingWebsocketStatus();
+          break;
+        default:
+          {
+            if (address) {
+              startPolling();
+            } else {
+              cleanup();
+            }
+          }
+          break;
+      }
+    }
+  );
+
+  subscriptions.set(
+    SubscriptionsEnum.websocketStatus,
+    unsubscribeWebsocketStatus
+  );
+  subscriptions.set(SubscriptionsEnum.websocketCleanup, cleanup);
+  return { cleanup };
 }

--- a/src/core/providers/DappProvider/helpers/login/login.ts
+++ b/src/core/providers/DappProvider/helpers/login/login.ts
@@ -1,4 +1,5 @@
 import { registerWebsocketListener } from 'core/methods/initApp/websocket/registerWebsocket';
+import { trackTransactions } from 'core/methods/trackTransactions/trackTransactions';
 import { IProvider } from 'core/providers/types/providerFactory.types';
 import { nativeAuth } from 'services/nativeAuth';
 import { NativeAuthConfigType } from 'services/nativeAuth/nativeAuth.types';
@@ -77,7 +78,8 @@ async function loginWithNativeToken(
     throw new Error('Failed to fetch account');
   }
 
-  await registerWebsocketListener();
+  await registerWebsocketListener(accountDetails.address);
+  trackTransactions();
 
   return {
     address: accountDetails?.address || address,
@@ -97,7 +99,8 @@ export async function login(provider: IProvider) {
 
   const data = await loginWithoutNativeToken(provider);
 
-  await registerWebsocketListener();
+  await registerWebsocketListener(data.address);
+  trackTransactions();
 
   return data;
 }

--- a/src/core/providers/DappProvider/helpers/logout/logout.ts
+++ b/src/core/providers/DappProvider/helpers/logout/logout.ts
@@ -1,5 +1,7 @@
+import { subscriptions } from 'constants/storage.constants';
 import { safeWindow } from 'constants/window.constants';
 import { getAddress } from 'core/methods/account/getAddress';
+import { closeConnectionRef } from 'core/methods/initApp/websocket/registerWebsocket';
 import {
   IProvider,
   ProviderTypeEnum
@@ -57,6 +59,10 @@ export async function logout({
       );
     }
 
+    // Clear all active subscriptions on logout
+    subscriptions.forEach((unsubscribe) => unsubscribe());
+    subscriptions.clear();
+    closeConnectionRef();
     await provider.logout();
   } catch (err) {
     console.error('Logging out error:', err);

--- a/src/store/actions/account/accountActions.ts
+++ b/src/store/actions/account/accountActions.ts
@@ -1,3 +1,4 @@
+import { WebsocketConnectionStatusEnum } from 'core/methods/initApp/websocket/websocket.constants';
 import {
   BatchTransactionsWSResponseType,
   LedgerAccountType
@@ -44,6 +45,15 @@ export const setWalletConnectAccount = (walletConnectAccount: string | null) =>
     },
     false,
     'setWalletConnectAccount'
+  );
+
+export const setWebsocketStatus = (status: WebsocketConnectionStatusEnum) =>
+  getStore().setState(
+    ({ account: state }) => {
+      state.websocketStatus = status;
+    },
+    false,
+    'setWebsocketStatus'
   );
 
 export const setWebsocketEvent = (message: string) =>

--- a/src/store/slices/account/account.types.ts
+++ b/src/store/slices/account/account.types.ts
@@ -1,3 +1,4 @@
+import { WebsocketConnectionStatusEnum } from 'core/methods/initApp/websocket/websocket.constants';
 import { AccountType } from 'types/account.types';
 
 export interface LedgerAccountType {
@@ -18,6 +19,7 @@ export type AccountSliceType = {
   publicKey: string;
   ledgerAccount: LedgerAccountType | null;
   walletConnectAccount: string | null;
+  websocketStatus: WebsocketConnectionStatusEnum;
   websocketEvent: {
     timestamp: number;
     message: string;

--- a/src/store/slices/account/accountSlice.ts
+++ b/src/store/slices/account/accountSlice.ts
@@ -1,4 +1,5 @@
 import { StateCreator } from 'zustand/vanilla';
+import { WebsocketConnectionStatusEnum } from 'core/methods/initApp/websocket/websocket.constants';
 import { StoreType, MutatorsIn } from 'store/store.types';
 import { AccountSliceType } from './account.types';
 import { emptyAccount } from './emptyAccount';
@@ -7,6 +8,7 @@ export const initialState: AccountSliceType = {
   address: '',
   websocketEvent: null,
   websocketBatchEvent: null,
+  websocketStatus: WebsocketConnectionStatusEnum.NOT_INITIALIZED,
   accounts: { '': emptyAccount },
   ledgerAccount: null,
   publicKey: '',

--- a/src/types/subscriptions.type.ts
+++ b/src/types/subscriptions.type.ts
@@ -1,0 +1,5 @@
+export enum SubscriptionsEnum {
+  websocketStatus = 'websocketStatus',
+  websocketEvent = 'websocketEvent',
+  websocketCleanup = 'websocketCleanup'
+}


### PR DESCRIPTION
### Issue
- The WebSocket and polling mechanisms are not functioning correctly during `initApp` due to the use of a plain (vanilla) Zustand store. Specifically, `isLoggedIn` does not update reactively unless store.subscribe is explicitly called.
- The transaction tracker cannot detect the WebSocket connection status. As a result, it always falls back to polling, even when a WebSocket connection is available.
- WebSocket retry mechanism does not work properly as it only retries only once.

### Reproduce
Issue exists on version `0.0.0-alpha.19` of sdk-dapp.

### Root cause
- the selector used in `initApp` does not actively observe changes to the WebSocket connection status.

### Fix
- create a websocketStatus inside account in order to subscribe for status changes and execute based on each status.
- rework retry mechanism to execute at least 3 times. If connection is established after those 3 times, fallback to polling mechanism.

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
