### PR TITLE
Uniform sign error toasts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed canceling transactions creates different toasts](https://github.com/multiversx/mx-sdk-dapp-core/pull/140)
 - [Prevent multiple initApp executions](https://github.com/multiversx/mx-sdk-dapp-core/pull/138)
 
 ## [[0.0.0-alpha.19](https://github.com/multiversx/mx-sdk-dapp-core/pull/137)] - 2025-04-10

--- a/src/core/providers/DappProvider/helpers/signErrors/handleSignError.ts
+++ b/src/core/providers/DappProvider/helpers/signErrors/handleSignError.ts
@@ -33,8 +33,6 @@ const getUserError = (error: string) => {
       return value;
     }
   }
-  console.log('\x1b[42m%s\x1b[0m', 'errors', { error });
-
   return SigningErrorsEnum.errorSigning;
 };
 
@@ -45,10 +43,12 @@ export function handleSignError(
   const originalError = (error as Error)?.message;
   const errorMessage = getUserError(originalError);
 
-  console.log('\x1b[42m%s\x1b[0m', 'errors', { originalError, error, type });
+  const isKnownError = errorMessage !== SigningErrorsEnum.errorSigning;
 
-  const state = Object.keys(states).includes(type)
-    ? states[type]
+  const errorType = isKnownError ? 'warning' : type;
+
+  const state = Object.keys(states).includes(errorType)
+    ? states[errorType]
     : states.error;
 
   const { toastId, iconClassName, title } = state;

--- a/src/core/providers/DappProvider/helpers/signErrors/handleSignError.ts
+++ b/src/core/providers/DappProvider/helpers/signErrors/handleSignError.ts
@@ -20,12 +20,32 @@ const states = {
   }
 };
 
+const errorsMap = {
+  extensionResponse: 'Unable to sign transactions', // extension
+  'Transaction canceled': 'Transaction canceled', // web wallet
+  'cancelled by user': 'Transaction signing cancelled by user', // custom
+  'denied by the user': 'Transaction signing denied by the user' // ledger
+};
+
+const getUserError = (error: string) => {
+  for (const [key, value] of Object.entries(errorsMap)) {
+    if (error.includes(key)) {
+      return value;
+    }
+  }
+  console.log('\x1b[42m%s\x1b[0m', 'errors', { error });
+
+  return SigningErrorsEnum.errorSigning;
+};
+
 export function handleSignError(
   error: unknown,
   type: 'error' | 'warning' = 'error'
 ) {
   const originalError = (error as Error)?.message;
-  const errorMessage = originalError || SigningErrorsEnum.errorSigning;
+  const errorMessage = getUserError(originalError);
+
+  console.log('\x1b[42m%s\x1b[0m', 'errors', { originalError, error, type });
 
   const state = Object.keys(states).includes(type)
     ? states[type]

--- a/src/core/providers/strategies/ExtensionProviderStrategy/ExtensionProviderStrategy.ts
+++ b/src/core/providers/strategies/ExtensionProviderStrategy/ExtensionProviderStrategy.ts
@@ -92,9 +92,8 @@ export class ExtensionProviderStrategy {
 
       return signedTransactions;
     } catch (error) {
-      console.log('\x1b[42m%s\x1b[0m', 'extension sign denied', { error });
+      await onClose({ shouldCancelAction: false }); // action was triggered by user in extension, no need to retrigger it
 
-      await onClose({ shouldCancelAction: true });
       throw error;
     } finally {
       manager.closeAndReset();

--- a/src/core/providers/strategies/ExtensionProviderStrategy/ExtensionProviderStrategy.ts
+++ b/src/core/providers/strategies/ExtensionProviderStrategy/ExtensionProviderStrategy.ts
@@ -92,6 +92,8 @@ export class ExtensionProviderStrategy {
 
       return signedTransactions;
     } catch (error) {
+      console.log('\x1b[42m%s\x1b[0m', 'extension sign denied', { error });
+
       await onClose({ shouldCancelAction: true });
       throw error;
     } finally {

--- a/src/core/providers/strategies/LedgerProviderStrategy/LedgerProviderStrategy.ts
+++ b/src/core/providers/strategies/LedgerProviderStrategy/LedgerProviderStrategy.ts
@@ -183,6 +183,9 @@ export class LedgerProviderStrategy {
     return signedMessage;
   };
 
+  /**
+   * Makes sure the device is accessible and if not, tries to initialize a new provider
+   */
   private rebuildProvider = async () => {
     try {
       await this.provider?.getAddress(); // can communicate with device

--- a/src/core/providers/strategies/LedgerProviderStrategy/helpers/signLedgerMessage.ts
+++ b/src/core/providers/strategies/LedgerProviderStrategy/helpers/signLedgerMessage.ts
@@ -8,7 +8,7 @@ export async function signLedgerMessage({
   handleSignMessage
 }: {
   message: Message;
-  handleSignMessage: (message: Message) => Promise<Message>;
+  handleSignMessage: (msg: Message) => Promise<Message>;
 }): Promise<Message> {
   try {
     const signedMessage = await signMessage({
@@ -18,7 +18,7 @@ export async function signLedgerMessage({
     });
     return signedMessage;
   } catch (error) {
-    const { errorMessage: message } = getLedgerErrorCodes(error);
-    throw message ? { message } : error;
+    const { errorMessage } = getLedgerErrorCodes(error);
+    throw errorMessage ? { message: errorMessage } : error;
   }
 }

--- a/src/core/providers/strategies/WalletConnectProviderStrategy/WalletConnectProviderStrategy.ts
+++ b/src/core/providers/strategies/WalletConnectProviderStrategy/WalletConnectProviderStrategy.ts
@@ -70,7 +70,7 @@ export class WalletConnectProviderStrategy {
     await this.createEventBus(options.anchor);
 
     if (!this.provider && this.config) {
-      const { walletConnectProvider, dappMethods } =
+      const { walletConnectProvider, dappMethods: dAppMethods } =
         await this.createWalletConnectProvider(this.config);
 
       // Bind in order to break reference
@@ -83,7 +83,7 @@ export class WalletConnectProviderStrategy {
       );
 
       this.provider = walletConnectProvider;
-      this.methods = dappMethods;
+      this.methods = dAppMethods;
     }
 
     if (this.provider) {


### PR DESCRIPTION
### Issue
Canceling transactions creates different toasts

### Root cause
Error messages in providers are implemented with different messages

### Fix
Create a message object map and make uniform handling of errors

### Additional changes
Fix cancelling Extension transactions blocked flow (no need to retrigger the cancel action in extension)
Minor linting

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
