### PR TITLE
Added providers customization support

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-
+- [Added providers customization support](https://github.com/multiversx/mx-sdk-dapp-core/pull/153)
 - [Fixed multisig login](https://github.com/multiversx/mx-sdk-dapp-core/pull/150)
 - [Fixed Ledger address table pagination transition state](https://github.com/multiversx/mx-sdk-dapp-core/pull/149)
 - [Removed unnecessary next and previous Ledger address table pagination handlers](https://github.com/multiversx/mx-sdk-dapp-core/pull/148)

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -7,3 +7,4 @@ export * from './storage.constants';
 export * from './webWalletProvider.constants';
 export * from './window.constants';
 export * from './websocket.constants';
+export * from './providerFactory.constants';

--- a/src/constants/providerFactory.constants.ts
+++ b/src/constants/providerFactory.constants.ts
@@ -1,0 +1,11 @@
+import { ProviderTypeEnum } from 'core/providers/types/providerFactory.types';
+
+export const providerLabels: Record<string, string> = {
+  [ProviderTypeEnum.crossWindow]: 'MultiversX Web Wallet',
+  [ProviderTypeEnum.extension]: 'MultiversX Wallet Extension',
+  [ProviderTypeEnum.walletConnect]: 'xPortal App',
+  [ProviderTypeEnum.ledger]: 'Ledger',
+  [ProviderTypeEnum.metamask]: 'MetaMask Snap',
+  [ProviderTypeEnum.passkey]: 'Passkey',
+  [ProviderTypeEnum.none]: ''
+};

--- a/src/core/managers/UnlockPanelManager/UnlockPanelManager.ts
+++ b/src/core/managers/UnlockPanelManager/UnlockPanelManager.ts
@@ -3,7 +3,6 @@ import { ProviderFactory } from 'core/providers/ProviderFactory';
 import {
   ICustomProviderBase,
   IProviderFactory,
-  providerLabels,
   ProviderTypeEnum
 } from 'core/providers/types/providerFactory.types';
 import { MvxUnlockPanel } from 'lib/sdkDappCoreUi';
@@ -17,6 +16,7 @@ import {
   UnlockPanelEventsEnum,
   UnlockPanelManagerInitParamsType
 } from './UnlockPanelManager.types';
+import { providerLabels } from 'constants/providerFactory.constants';
 
 export class UnlockPanelManager {
   private static instance: UnlockPanelManager;
@@ -146,29 +146,33 @@ export class UnlockPanelManager {
         type !== ProviderTypeEnum.none && type !== ProviderTypeEnum.webview
     );
 
-    const allAvailableTypes = [
+    const allAvailableProviderTypes = [
       ...enumProviderTypes,
       ...customProviders.map((p) => p.type)
     ];
 
-    const allowedTypes = this.allowedProviders
-      ? this.allowedProviders.filter((type) => allAvailableTypes.includes(type))
-      : allAvailableTypes;
+    const allowedProviderTypes = this.allowedProviders
+      ? this.allowedProviders.filter((type) =>
+          allAvailableProviderTypes.includes(type)
+        )
+      : allAvailableProviderTypes;
 
-    const result: ICustomProviderBase[] = allowedTypes.map((type) => {
-      const custom = customProviders.find(
-        (customProvider) => customProvider.type === type
-      );
-      if (custom) {
-        return custom;
+    const providerList: ICustomProviderBase[] = allowedProviderTypes.map(
+      (type) => {
+        const custom = customProviders.find(
+          (customProvider) => customProvider.type === type
+        );
+        if (custom) {
+          return custom;
+        }
+
+        return {
+          name: providerLabels[type as ProviderTypeEnum] ?? type,
+          type
+        };
       }
+    );
 
-      return {
-        name: providerLabels[type as ProviderTypeEnum] ?? type,
-        type
-      };
-    });
-
-    return result;
+    return providerList;
   }
 }

--- a/src/core/managers/UnlockPanelManager/UnlockPanelManager.ts
+++ b/src/core/managers/UnlockPanelManager/UnlockPanelManager.ts
@@ -155,23 +155,19 @@ export class UnlockPanelManager {
       ? this.allowedProviders.filter((type) => allAvailableTypes.includes(type))
       : allAvailableTypes;
 
-    const allowedTypeSet = new Set(allowedTypes);
-
-    const result: ICustomProviderBase[] = Array.from(allowedTypeSet).map(
-      (type) => {
-        const custom = customProviders.find(
-          (customProvider) => customProvider.type === type
-        );
-        if (custom) {
-          return custom;
-        }
-
-        return {
-          name: providerLabels[type as ProviderTypeEnum] ?? type,
-          type
-        };
+    const result: ICustomProviderBase[] = allowedTypes.map((type) => {
+      const custom = customProviders.find(
+        (customProvider) => customProvider.type === type
+      );
+      if (custom) {
+        return custom;
       }
-    );
+
+      return {
+        name: providerLabels[type as ProviderTypeEnum] ?? type,
+        type
+      };
+    });
 
     return result;
   }

--- a/src/core/managers/UnlockPanelManager/UnlockPanelManager.ts
+++ b/src/core/managers/UnlockPanelManager/UnlockPanelManager.ts
@@ -1,7 +1,7 @@
 import { UITagsEnum } from 'constants/UITags.enum';
 import { ProviderFactory } from 'core/providers/ProviderFactory';
 import {
-  ICustomProviderBase,
+  IProviderBase,
   IProviderFactory,
   ProviderTypeEnum
 } from 'core/providers/types/providerFactory.types';
@@ -138,7 +138,7 @@ export class UnlockPanelManager {
     return takesZeroArguments;
   }
 
-  private static getProvidersList(): ICustomProviderBase[] {
+  private static getProvidersList(): IProviderBase[] {
     const customProviders = ProviderFactory.customProviders;
 
     const enumProviderTypes = Object.values(ProviderTypeEnum).filter(
@@ -157,21 +157,19 @@ export class UnlockPanelManager {
         )
       : allAvailableProviderTypes;
 
-    const providerList: ICustomProviderBase[] = allowedProviderTypes.map(
-      (type) => {
-        const custom = customProviders.find(
-          (customProvider) => customProvider.type === type
-        );
-        if (custom) {
-          return custom;
-        }
-
-        return {
-          name: providerLabels[type as ProviderTypeEnum] ?? type,
-          type
-        };
+    const providerList: IProviderBase[] = allowedProviderTypes.map((type) => {
+      const custom = customProviders.find(
+        (customProvider) => customProvider.type === type
+      );
+      if (custom) {
+        return custom;
       }
-    );
+
+      return {
+        name: providerLabels[type as ProviderTypeEnum] ?? type,
+        type
+      };
+    });
 
     return providerList;
   }

--- a/src/core/managers/UnlockPanelManager/UnlockPanelManager.types.ts
+++ b/src/core/managers/UnlockPanelManager/UnlockPanelManager.types.ts
@@ -1,4 +1,6 @@
 import {
+  ICustomProvider,
+  ICustomProviderBase,
   IProviderFactory,
   ProviderTypeEnum
 } from 'core/providers/types/providerFactory.types';
@@ -12,13 +14,19 @@ export enum UnlockPanelEventsEnum {
 
 export interface IUnlockPanel {
   isOpen: boolean;
-  allowedProviders?: ProviderTypeEnum[] | null;
+  allowedProviders?: ICustomProviderBase[] | null;
 }
 
 export type LoginFunctonType = ({
   type,
   anchor
 }: IProviderFactory) => Promise<void>;
+
+export type AllowedProviderType = ICustomProvider['type'];
+
+export type CustomProviderViewType<
+  T extends ProviderTypeEnum = ProviderTypeEnum
+> = Omit<ICustomProvider<T>, 'constructor'>;
 
 export type LoginCallbackType = () => void;
 
@@ -49,5 +57,5 @@ export type UnlockPanelManagerInitParamsType = {
   /**
    * List of allowed providers
    */
-  allowedProviders?: ProviderTypeEnum[] | null;
+  allowedProviders?: AllowedProviderType[] | null;
 };

--- a/src/core/managers/UnlockPanelManager/UnlockPanelManager.types.ts
+++ b/src/core/managers/UnlockPanelManager/UnlockPanelManager.types.ts
@@ -1,6 +1,6 @@
 import {
   ICustomProvider,
-  ICustomProviderBase,
+  IProviderBase,
   IProviderFactory,
   ProviderTypeEnum
 } from 'core/providers/types/providerFactory.types';
@@ -14,7 +14,7 @@ export enum UnlockPanelEventsEnum {
 
 export interface IUnlockPanel {
   isOpen: boolean;
-  allowedProviders?: ICustomProviderBase[] | null;
+  allowedProviders?: IProviderBase[] | null;
 }
 
 export type LoginFunctonType = ({

--- a/src/core/methods/initApp/initApp.ts
+++ b/src/core/methods/initApp/initApp.ts
@@ -5,7 +5,10 @@ import { ToastManager } from 'core/managers/internal/ToastManager/ToastManager';
 import { login } from 'core/providers/DappProvider/helpers/login/login';
 import { restoreProvider } from 'core/providers/helpers/restoreProvider';
 import { ProviderFactory } from 'core/providers/ProviderFactory';
-import { ProviderTypeEnum } from 'core/providers/types/providerFactory.types';
+import {
+  ICustomProvider,
+  ProviderTypeEnum
+} from 'core/providers/types/providerFactory.types';
 import { getDefaultNativeAuthConfig } from 'services/nativeAuth/methods/getDefaultNativeAuthConfig';
 import { NativeAuthConfigType } from 'services/nativeAuth/nativeAuth.types';
 import { initializeNetwork } from 'store/actions';
@@ -111,12 +114,17 @@ export async function initApp({
     signTransactionsStateManager.init()
   ]);
 
-  const usedProviders = [
+  const usedProviders: ICustomProvider[] = [
     ...((safeWindow as any)?.multiversx?.providers ?? []),
     ...(customProviders || [])
   ];
 
-  ProviderFactory.customProviders(usedProviders || []);
+  const uniqueProviders = usedProviders.filter(
+    (provider, index, arr) =>
+      index === arr.findIndex((item) => item.type === provider.type)
+  );
+
+  ProviderFactory.customProviders = uniqueProviders || [];
 
   if (isLoggedIn && !isAppInitialized) {
     await restoreProvider();

--- a/src/core/providers/ProviderFactory.ts
+++ b/src/core/providers/ProviderFactory.ts
@@ -26,8 +26,12 @@ import {
 export class ProviderFactory {
   private static _customProviders: ICustomProvider[] = [];
 
-  public static customProviders(providers: ICustomProvider[]) {
+  public static set customProviders(providers: ICustomProvider[]) {
     this._customProviders = providers;
+  }
+
+  public static get customProviders() {
+    return this._customProviders;
   }
 
   public static async create({

--- a/src/core/providers/strategies/CrossWindowProviderStrategy/CrossWindowProviderStrategy.ts
+++ b/src/core/providers/strategies/CrossWindowProviderStrategy/CrossWindowProviderStrategy.ts
@@ -1,10 +1,8 @@
 import { Message, Transaction } from '@multiversx/sdk-core/out';
 import { isBrowserWithPopupConfirmation } from 'constants/browser.constants';
 import { PendingTransactionsEventsEnum } from 'core/managers/internal/PendingTransactionsStateManager/types/pendingTransactions.types';
-import {
-  IProvider,
-  providerLabels
-} from 'core/providers/types/providerFactory.types';
+import { IProvider } from 'core/providers/types/providerFactory.types';
+import { providerLabels } from 'constants/providerFactory.constants';
 import { CrossWindowProvider } from 'lib/sdkWebWalletCrossWindowProvider';
 import { crossWindowConfigSelector } from 'store/selectors';
 import { networkSelector } from 'store/selectors/networkSelectors';

--- a/src/core/providers/strategies/ExtensionProviderStrategy/ExtensionProviderStrategy.ts
+++ b/src/core/providers/strategies/ExtensionProviderStrategy/ExtensionProviderStrategy.ts
@@ -2,10 +2,8 @@ import { Message, Transaction } from '@multiversx/sdk-core/out';
 import { ExtensionProvider } from '@multiversx/sdk-extension-provider/out/extensionProvider';
 import { PendingTransactionsEventsEnum } from 'core/managers/internal/PendingTransactionsStateManager/types/pendingTransactions.types';
 
-import {
-  IProvider,
-  providerLabels
-} from 'core/providers/types/providerFactory.types';
+import { IProvider } from 'core/providers/types/providerFactory.types';
+import { providerLabels } from 'constants/providerFactory.constants';
 import { ProviderErrorsEnum } from 'types/provider.types';
 import { getPendingTransactionsHandlers } from '../helpers/getPendingTransactionsHandlers';
 import { signMessage } from '../helpers/signMessage/signMessage';

--- a/src/core/providers/strategies/IframeProviderStrategy/IframeProviderStrategy.ts
+++ b/src/core/providers/strategies/IframeProviderStrategy/IframeProviderStrategy.ts
@@ -4,10 +4,8 @@ import { IframeLoginTypes } from '@multiversx/sdk-web-wallet-iframe-provider/out
 
 import { PendingTransactionsEventsEnum } from 'core/managers/internal/PendingTransactionsStateManager/types/pendingTransactions.types';
 import { getAccount } from 'core/methods/account/getAccount';
-import {
-  IProvider,
-  providerLabels
-} from 'core/providers/types/providerFactory.types';
+import { IProvider } from 'core/providers/types/providerFactory.types';
+import { providerLabels } from 'constants/providerFactory.constants';
 import { networkSelector } from 'store/selectors/networkSelectors';
 import { getState } from 'store/store';
 import { ProviderErrorsEnum } from 'types/provider.types';

--- a/src/core/providers/strategies/LedgerProviderStrategy/helpers/signLedgerMessage.ts
+++ b/src/core/providers/strategies/LedgerProviderStrategy/helpers/signLedgerMessage.ts
@@ -1,5 +1,5 @@
 import { Message } from '@multiversx/sdk-core/out';
-import { providerLabels } from 'core/providers/types/providerFactory.types';
+import { providerLabels } from 'constants/providerFactory.constants';
 import { getLedgerErrorCodes } from './getLedgerErrorCodes';
 import { signMessage } from '../../helpers/signMessage/signMessage';
 

--- a/src/core/providers/strategies/WalletConnectProviderStrategy/WalletConnectProviderStrategy.ts
+++ b/src/core/providers/strategies/WalletConnectProviderStrategy/WalletConnectProviderStrategy.ts
@@ -12,10 +12,8 @@ import { WalletConnectStateManager } from 'core/managers/internal/WalletConnectS
 import { getIsLoggedIn } from 'core/methods/account/getIsLoggedIn';
 import { getAccountProvider } from 'core/providers/helpers/accountProvider';
 import { getPendingTransactionsHandlers } from 'core/providers/strategies/helpers';
-import {
-  IProvider,
-  providerLabels
-} from 'core/providers/types/providerFactory.types';
+import { IProvider } from 'core/providers/types/providerFactory.types';
+import { providerLabels } from 'constants/providerFactory.constants';
 import { defineCustomElements, IEventBus } from 'lib/sdkDappCoreUi';
 import { logoutAction } from 'store/actions';
 import {

--- a/src/core/providers/types/providerFactory.types.ts
+++ b/src/core/providers/types/providerFactory.types.ts
@@ -24,28 +24,23 @@ export interface IProviderConfig {
 }
 
 export enum ProviderTypeEnum {
-  iframe = 'iframe',
   crossWindow = 'crossWindow',
   extension = 'extension',
   walletConnect = 'walletConnect',
   ledger = 'ledger',
-  opera = 'opera',
   metamask = 'metamask',
   passkey = 'passkey',
   webview = 'webview',
   none = ''
 }
 
-export const providerLabels: Record<ProviderTypeEnum, string> = {
-  [ProviderTypeEnum.iframe]: 'Linked Wallet',
-  [ProviderTypeEnum.crossWindow]: 'Web Wallet',
-  [ProviderTypeEnum.extension]: 'De-Fi Wallet',
-  [ProviderTypeEnum.walletConnect]: 'xPortal Wallet',
-  [ProviderTypeEnum.ledger]: 'Ledger Device',
-  [ProviderTypeEnum.opera]: 'Opera Wallet',
-  [ProviderTypeEnum.metamask]: 'MetaMask Wallet',
-  [ProviderTypeEnum.passkey]: 'Passkey Wallet',
-  [ProviderTypeEnum.webview]: 'App',
+export const providerLabels: Record<string, string> = {
+  [ProviderTypeEnum.crossWindow]: 'MultiversX Web Wallet',
+  [ProviderTypeEnum.extension]: 'MultiversX Wallet Extension',
+  [ProviderTypeEnum.walletConnect]: 'xPortal App',
+  [ProviderTypeEnum.ledger]: 'Ledger',
+  [ProviderTypeEnum.metamask]: 'MetaMask Snap',
+  [ProviderTypeEnum.passkey]: 'Passkey',
   [ProviderTypeEnum.none]: ''
 };
 
@@ -56,11 +51,14 @@ export interface IProviderFactory<
   anchor?: HTMLElement;
 }
 
-export interface ICustomProvider<
+export interface ICustomProviderBase<
   T extends ProviderTypeEnum = ProviderTypeEnum
 > {
   name: string;
   type: T[keyof T];
-  icon: string;
+  iconUrl?: string;
+}
+export interface ICustomProvider<T extends ProviderTypeEnum = ProviderTypeEnum>
+  extends ICustomProviderBase<T> {
   constructor: (address?: string) => Promise<IProvider>;
 }

--- a/src/core/providers/types/providerFactory.types.ts
+++ b/src/core/providers/types/providerFactory.types.ts
@@ -41,14 +41,12 @@ export interface IProviderFactory<
   anchor?: HTMLElement;
 }
 
-export interface ICustomProviderBase<
-  T extends ProviderTypeEnum = ProviderTypeEnum
-> {
+export interface IProviderBase<T extends ProviderTypeEnum = ProviderTypeEnum> {
   name: string;
   type: T[keyof T];
   iconUrl?: string;
 }
 export interface ICustomProvider<T extends ProviderTypeEnum = ProviderTypeEnum>
-  extends ICustomProviderBase<T> {
+  extends IProviderBase<T> {
   constructor: (address?: string) => Promise<IProvider>;
 }

--- a/src/core/providers/types/providerFactory.types.ts
+++ b/src/core/providers/types/providerFactory.types.ts
@@ -34,16 +34,6 @@ export enum ProviderTypeEnum {
   none = ''
 }
 
-export const providerLabels: Record<string, string> = {
-  [ProviderTypeEnum.crossWindow]: 'MultiversX Web Wallet',
-  [ProviderTypeEnum.extension]: 'MultiversX Wallet Extension',
-  [ProviderTypeEnum.walletConnect]: 'xPortal App',
-  [ProviderTypeEnum.ledger]: 'Ledger',
-  [ProviderTypeEnum.metamask]: 'MetaMask Snap',
-  [ProviderTypeEnum.passkey]: 'Passkey',
-  [ProviderTypeEnum.none]: ''
-};
-
 export interface IProviderFactory<
   T extends ProviderTypeEnum = ProviderTypeEnum
 > {


### PR DESCRIPTION
### Feature
Enhancements to the `UnlockPanelManager` and provider management system to support dynamic provider configurations and improve flexibility.

### Reproduce
Issue exists on version `0.` of sdk-dapp-core-ui.

### Root cause
The existing implementation of `UnlockPanelManager` and `ProviderFactory` lacked flexibility in handling custom providers and dynamically generating allowed provider lists. Additionally, the `providerLabels` structure was rigid and did not fully support custom provider types.

### Fix
- Added a new `getProvidersList()` method in `UnlockPanelManager` to dynamically generate allowed providers.
- Updated `allowedProviders` to use the new `AllowedProviderType` type for better flexibility.
- Refactored `ProviderFactory` to include getter and setter methods for managing custom providers, ensuring uniqueness.
- Updated `providerLabels` to a more extensible structure.
- Adjusted related types and interfaces to align with the new provider management system.

### Additional changes
- Improved deduplication logic for custom providers in `initApp`.
- Introduced new types (`AllowedProviderType`, `ICustomProviderBase`) for better type safety and separation of concerns.

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing  
[] Unit tests