### PR TITLE
Fixed crossWindow double logout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- [Fixed login double cross-window wallet disconnect](https://github.com/multiversx/mx-sdk-dapp-core/pull/159)
+- [Fixed login double cross-window wallet disconnect](https://github.com/multiversx/mx-sdk-dapp-core/pull/163)
 - [Fixed ledger double screen](https://github.com/multiversx/mx-sdk-dapp-core/pull/158)
 - [Updated providers order](https://github.com/multiversx/mx-sdk-dapp-core/pull/157)
 - [Added support for dapps inside iframe/webview](https://github.com/multiversx/mx-sdk-dapp-core/pull/156)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fixed login double cross-window wallet disconnect](https://github.com/multiversx/mx-sdk-dapp-core/pull/159)
 - [Fixed ledger double screen](https://github.com/multiversx/mx-sdk-dapp-core/pull/158)
 - [Updated providers order](https://github.com/multiversx/mx-sdk-dapp-core/pull/157)
 - [Added support for dapps inside iframe/webview](https://github.com/multiversx/mx-sdk-dapp-core/pull/156)

--- a/src/core/providers/strategies/BaseProviderStrategy/BaseProviderStrategy.ts
+++ b/src/core/providers/strategies/BaseProviderStrategy/BaseProviderStrategy.ts
@@ -14,7 +14,7 @@ export abstract class BaseProviderStrategy {
   protected loginAbortController: AbortController | null = null;
 
   constructor(address?: string) {
-    this.address = address || '';
+    this.address = address ?? '';
   }
 
   public async login(
@@ -24,11 +24,12 @@ export abstract class BaseProviderStrategy {
       throw new Error(ProviderErrorsEnum.notInitialized);
     }
 
-    if (
+    const shouldSkipCancelLogin =
       options &&
       'shouldCancelLogin' in options &&
-      options.shouldCancelLogin
-    ) {
+      options.shouldCancelLogin === true;
+
+    if (!shouldSkipCancelLogin) {
       this.cancelLogin();
     }
 

--- a/src/core/providers/strategies/BaseProviderStrategy/BaseProviderStrategy.ts
+++ b/src/core/providers/strategies/BaseProviderStrategy/BaseProviderStrategy.ts
@@ -3,8 +3,6 @@ import { getAddress } from 'core/methods/account/getAddress';
 import { ProviderErrorsEnum } from 'types/provider.types';
 
 export type LoginOptionsTypes = {
-  addressIndex?: number;
-  callbackUrl?: string;
   token?: string;
 };
 
@@ -19,14 +17,20 @@ export abstract class BaseProviderStrategy {
     this.address = address || '';
   }
 
-  public login = async (
+  public async login(
     options?: LoginOptionsTypes
-  ): Promise<{ address: string; signature: string }> => {
+  ): Promise<{ address: string; signature: string }> {
     if (!this._login) {
       throw new Error(ProviderErrorsEnum.notInitialized);
     }
 
-    this.cancelLogin();
+    if (
+      options &&
+      'shouldCancelLogin' in options &&
+      options.shouldCancelLogin
+    ) {
+      this.cancelLogin();
+    }
 
     if (this.loginAbortController) {
       this.loginAbortController.abort();
@@ -56,7 +60,7 @@ export abstract class BaseProviderStrategy {
       this.loginAbortController = null;
       throw error;
     }
-  };
+  }
 
   public cancelLogin = () => {
     if (this.loginAbortController) {

--- a/src/core/providers/strategies/CrossWindowProviderStrategy/CrossWindowProviderStrategy.ts
+++ b/src/core/providers/strategies/CrossWindowProviderStrategy/CrossWindowProviderStrategy.ts
@@ -62,6 +62,7 @@ export class CrossWindowProviderStrategy extends BaseProviderStrategy {
       this.loginAbortController.abort();
     }
 
+    // is called instead of provider.cancelAction()
     CrossWindowProvider.getInstance().onDestroy();
     this.loginAbortController = null;
   };
@@ -142,7 +143,7 @@ export class CrossWindowProviderStrategy extends BaseProviderStrategy {
     }
   };
 
-  private signMessage = async (message: Message) => {
+  private readonly signMessage = async (message: Message) => {
     if (!this.provider || !this._signMessage) {
       throw new Error(ProviderErrorsEnum.notInitialized);
     }
@@ -158,7 +159,8 @@ export class CrossWindowProviderStrategy extends BaseProviderStrategy {
 
     return signedMessage;
   };
-  private setPopupConsent = () => {
+
+  private readonly setPopupConsent = () => {
     const crossWindowDappConfig = crossWindowConfigSelector(getState());
 
     if (!this.provider) {

--- a/src/core/providers/strategies/LedgerProviderStrategy/LedgerProviderStrategy.ts
+++ b/src/core/providers/strategies/LedgerProviderStrategy/LedgerProviderStrategy.ts
@@ -75,7 +75,7 @@ export class LedgerProviderStrategy extends BaseProviderStrategy {
     return this.buildProvider();
   };
 
-  private buildProvider = async () => {
+  private readonly buildProvider = async () => {
     if (!this.provider) {
       throw new Error(ProviderErrorsEnum.notInitialized);
     }
@@ -90,8 +90,8 @@ export class LedgerProviderStrategy extends BaseProviderStrategy {
     return provider;
   };
 
-  private ledgerLogin = async (
-    options?: LoginOptionsTypes
+  private readonly ledgerLogin = async (
+    options?: LoginOptionsTypes & { addressIndex?: number }
   ): Promise<{ address: string; signature: string }> => {
     if (!this.provider) {
       throw new Error(ProviderErrorsEnum.notInitialized);
@@ -104,7 +104,7 @@ export class LedgerProviderStrategy extends BaseProviderStrategy {
     });
     return {
       address,
-      signature: signature || ''
+      signature: signature ?? ''
     };
   };
 
@@ -119,13 +119,13 @@ export class LedgerProviderStrategy extends BaseProviderStrategy {
       options,
       config: this.config!,
       manager: ledgerConnectManager,
-      provider: this.provider!,
+      provider: this.provider,
       eventBus: this.eventBus,
       login: this.ledgerLogin.bind(this)
     });
   };
 
-  private createEventBus = async (anchor?: HTMLElement) => {
+  private readonly createEventBus = async (anchor?: HTMLElement) => {
     const shouldInitiateLogin = !getIsLoggedIn();
 
     if (!shouldInitiateLogin) {
@@ -145,7 +145,7 @@ export class LedgerProviderStrategy extends BaseProviderStrategy {
     return this.eventBus;
   };
 
-  private signTransactions = async (transactions: Transaction[]) => {
+  private readonly signTransactions = async (transactions: Transaction[]) => {
     if (!this._signTransactions) {
       throw new Error(ProviderErrorsEnum.signTransactionsNotInitialized);
     }
@@ -160,7 +160,7 @@ export class LedgerProviderStrategy extends BaseProviderStrategy {
     return signedTransactions;
   };
 
-  private signMessage = async (message: Message): Promise<Message> => {
+  private readonly signMessage = async (message: Message): Promise<Message> => {
     if (!this.provider || !this._signMessage) {
       throw new Error(ProviderErrorsEnum.notInitialized);
     }
@@ -178,7 +178,7 @@ export class LedgerProviderStrategy extends BaseProviderStrategy {
   /**
    * Makes sure the device is accessible and if not, tries to initialize a new provider
    */
-  private rebuildProvider = async () => {
+  private readonly rebuildProvider = async () => {
     try {
       await this.provider?.getAddress(); // can communicate with device
     } catch (_err) {


### PR DESCRIPTION
### Issue
Cross window login focuses wallet tab twice

### Reproduce
First try to login with cross window, then cancel from wallet child window, then try to login with walletconnect, and a new wallet window is opened and closed immediately

### Root cause
Cross window provider was having an existing instance which was getting destroyed

### Fix
Overwrite the cancel login action within the cross provider strategy and call destroyed there

### Additional changes
Linting

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
