### PR TITLE
Add dynamic gas station metadata retrieval

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Added dynamic ppu](https://github.com/multiversx/mx-sdk-dapp-core/pull/165)
 - [Fixed cross-window skipLogin flag](https://github.com/multiversx/mx-sdk-dapp-core/pull/164)
 - [Fixed login double cross-window wallet disconnect](https://github.com/multiversx/mx-sdk-dapp-core/pull/163)
 - [Added webview provider tests](https://github.com/multiversx/mx-sdk-dapp-core/pull/161)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- [Added dynamic ppu](https://github.com/multiversx/mx-sdk-dapp-core/pull/165)
+- [Added dynamic ppu](https://github.com/multiversx/mx-sdk-dapp-core/pull/166)
 - [Fixed cross-window skipLogin flag](https://github.com/multiversx/mx-sdk-dapp-core/pull/164)
 - [Fixed login double cross-window wallet disconnect](https://github.com/multiversx/mx-sdk-dapp-core/pull/163)
 - [Added webview provider tests](https://github.com/multiversx/mx-sdk-dapp-core/pull/161)

--- a/src/apiCalls/configuration/getGasStationMetadata.ts
+++ b/src/apiCalls/configuration/getGasStationMetadata.ts
@@ -1,0 +1,41 @@
+import axios from 'axios';
+import { getCleanApiAddress } from 'apiCalls/configuration/getCleanApiAddress';
+import { NetworkType } from 'types/network.types';
+
+interface IGasStationApiResponse {
+  lastBlock: number;
+  fast: number;
+  faster: number;
+}
+
+const GAS_STATION_ENDPOINT = 'transactions/ppu';
+
+export async function getGasStationMetadataFromApi(
+  shard: number,
+  customApiAddress?: string
+): Promise<NetworkType['gasStationMetadata'] | null> {
+  const apiAddress = getCleanApiAddress(customApiAddress);
+  const gasStationUrl = `${apiAddress}/${GAS_STATION_ENDPOINT}/${shard}`;
+
+  try {
+    const { data } = await axios.get<IGasStationApiResponse>(gasStationUrl);
+
+    if (data) {
+      return {
+        [shard]: {
+          lastBlock: data.lastBlock,
+          fast: data.fast,
+          faster: data.faster
+        }
+      };
+    }
+    return null;
+  } catch (err) {
+    console.error(
+      'Error fetching gas station metadata from:',
+      gasStationUrl,
+      err
+    );
+    return null;
+  }
+}

--- a/src/core/methods/initApp/gastStationMetadata/initGasStationMetadata.ts
+++ b/src/core/methods/initApp/gastStationMetadata/initGasStationMetadata.ts
@@ -1,0 +1,49 @@
+import { getGasStationMetadataFromApi } from 'apiCalls/configuration/getGasStationMetadata';
+import { initializeNetworkConfig } from 'store/actions/network/networkActions';
+import { networkSelector } from 'store/selectors/networkSelectors';
+import { getState } from 'store/store';
+
+interface IInitGasStationMetadataParams {
+  shard: number;
+  apiAddress: string;
+}
+
+export async function initGasStationMetadata({
+  shard,
+  apiAddress
+}: IInitGasStationMetadataParams) {
+  if (shard == null) {
+    return;
+  }
+
+  try {
+    const fetchedGasMetadata = await getGasStationMetadataFromApi(
+      shard,
+      apiAddress
+    );
+
+    if (!fetchedGasMetadata?.[shard]?.lastBlock) {
+      return;
+    }
+
+    const network = networkSelector(getState());
+
+    const hasDifferentGasStationMetadata =
+      !network.gasStationMetadata ||
+      !network.gasStationMetadata[shard] ||
+      network.gasStationMetadata[shard].lastBlock !==
+        fetchedGasMetadata[shard].lastBlock;
+
+    if (hasDifferentGasStationMetadata) {
+      initializeNetworkConfig({
+        ...network,
+        gasStationMetadata: {
+          ...network.gasStationMetadata,
+          ...fetchedGasMetadata
+        }
+      });
+    }
+  } catch (err) {
+    console.error('Error fetching gas station metadata:', err);
+  }
+}

--- a/src/core/methods/initApp/gastStationMetadata/setGasStationMetadata.ts
+++ b/src/core/methods/initApp/gastStationMetadata/setGasStationMetadata.ts
@@ -3,15 +3,15 @@ import { initializeNetworkConfig } from 'store/actions/network/networkActions';
 import { networkSelector } from 'store/selectors/networkSelectors';
 import { getState } from 'store/store';
 
-interface IInitGasStationMetadataParams {
+interface ISetGasStationMetadataParams {
   shard: number;
   apiAddress: string;
 }
 
-export async function initGasStationMetadata({
+export async function setGasStationMetadata({
   shard,
   apiAddress
-}: IInitGasStationMetadataParams) {
+}: ISetGasStationMetadataParams) {
   if (shard == null) {
     return;
   }

--- a/src/core/methods/initApp/initApp.ts
+++ b/src/core/methods/initApp/initApp.ts
@@ -23,8 +23,9 @@ import { getIsInIframe } from 'utils/window/getIsInIframe';
 import { InitAppType } from './initApp.types';
 import { getIsLoggedIn } from '../account/getIsLoggedIn';
 import { registerWebsocketListener } from './websocket/registerWebsocket';
-import { getAccount } from '../account/getAccount';
 import { trackTransactions } from '../trackTransactions/trackTransactions';
+import { initGasStationMetadata } from './gastStationMetadata/initGasStationMetadata';
+import { getAccount } from '../account/getAccount';
 
 const defaultInitAppProps = {
   storage: {
@@ -134,6 +135,13 @@ export async function initApp({
     await restoreProvider();
     await registerWebsocketListener(account.address);
     trackTransactions();
+
+    if (account.shard != null) {
+      await initGasStationMetadata({
+        shard: Number(account.shard),
+        apiAddress
+      });
+    }
   }
 
   isAppInitialized = true;

--- a/src/core/methods/initApp/initApp.ts
+++ b/src/core/methods/initApp/initApp.ts
@@ -24,7 +24,7 @@ import { InitAppType } from './initApp.types';
 import { getIsLoggedIn } from '../account/getIsLoggedIn';
 import { registerWebsocketListener } from './websocket/registerWebsocket';
 import { trackTransactions } from '../trackTransactions/trackTransactions';
-import { initGasStationMetadata } from './gastStationMetadata/initGasStationMetadata';
+import { setGasStationMetadata } from './gastStationMetadata/setGasStationMetadata';
 import { getAccount } from '../account/getAccount';
 
 const defaultInitAppProps = {
@@ -138,7 +138,7 @@ export async function initApp({
   }
 
   if (account.shard != null) {
-    await initGasStationMetadata({
+    await setGasStationMetadata({
       shard: Number(account.shard),
       apiAddress
     });

--- a/src/core/methods/initApp/initApp.ts
+++ b/src/core/methods/initApp/initApp.ts
@@ -135,13 +135,13 @@ export async function initApp({
     await restoreProvider();
     await registerWebsocketListener(account.address);
     trackTransactions();
+  }
 
-    if (account.shard != null) {
-      await initGasStationMetadata({
-        shard: Number(account.shard),
-        apiAddress
-      });
-    }
+  if (account.shard != null) {
+    await initGasStationMetadata({
+      shard: Number(account.shard),
+      apiAddress
+    });
   }
 
   isAppInitialized = true;

--- a/src/core/providers/DappProvider/helpers/login/helpers/accountLogin.ts
+++ b/src/core/providers/DappProvider/helpers/login/helpers/accountLogin.ts
@@ -1,5 +1,5 @@
 import { getLatestNonce } from 'core/methods/account/getLatestNonce';
-import { initGasStationMetadata } from 'core/methods/initApp/gastStationMetadata/initGasStationMetadata';
+import { setGasStationMetadata } from 'core/methods/initApp/gastStationMetadata/setGasStationMetadata';
 import { registerWebsocketListener } from 'core/methods/initApp/websocket/registerWebsocket';
 import { trackTransactions } from 'core/methods/trackTransactions/trackTransactions';
 import { IProvider } from 'core/providers/types/providerFactory.types';
@@ -44,7 +44,7 @@ export async function accountLogin({
   trackTransactions();
 
   if (account.shard != null) {
-    await initGasStationMetadata({
+    await setGasStationMetadata({
       shard: Number(account.shard),
       apiAddress
     });

--- a/src/core/providers/DappProvider/helpers/login/helpers/accountLogin.ts
+++ b/src/core/providers/DappProvider/helpers/login/helpers/accountLogin.ts
@@ -1,4 +1,5 @@
 import { getLatestNonce } from 'core/methods/account/getLatestNonce';
+import { initGasStationMetadata } from 'core/methods/initApp/gastStationMetadata/initGasStationMetadata';
 import { registerWebsocketListener } from 'core/methods/initApp/websocket/registerWebsocket';
 import { trackTransactions } from 'core/methods/trackTransactions/trackTransactions';
 import { IProvider } from 'core/providers/types/providerFactory.types';
@@ -41,4 +42,11 @@ export async function accountLogin({
 
   await registerWebsocketListener(address);
   trackTransactions();
+
+  if (account.shard != null) {
+    await initGasStationMetadata({
+      shard: Number(account.shard),
+      apiAddress
+    });
+  }
 }

--- a/src/core/providers/strategies/ExtensionProviderStrategy/ExtensionProviderStrategy.ts
+++ b/src/core/providers/strategies/ExtensionProviderStrategy/ExtensionProviderStrategy.ts
@@ -1,13 +1,13 @@
 import { Message, Transaction } from '@multiversx/sdk-core/out';
 import { ExtensionProvider } from '@multiversx/sdk-extension-provider/out/extensionProvider';
+import { providerLabels } from 'constants/providerFactory.constants';
 import { PendingTransactionsEventsEnum } from 'core/managers/internal/PendingTransactionsStateManager/types/pendingTransactions.types';
 
 import { IProvider } from 'core/providers/types/providerFactory.types';
-import { providerLabels } from 'constants/providerFactory.constants';
 import { ProviderErrorsEnum } from 'types/provider.types';
+import { BaseProviderStrategy } from '../BaseProviderStrategy/BaseProviderStrategy';
 import { getPendingTransactionsHandlers } from '../helpers/getPendingTransactionsHandlers';
 import { signMessage } from '../helpers/signMessage/signMessage';
-import { BaseProviderStrategy } from '../BaseProviderStrategy/BaseProviderStrategy';
 
 export class ExtensionProviderStrategy extends BaseProviderStrategy {
   private provider: ExtensionProvider | null = null;

--- a/src/core/providers/strategies/IframeProviderStrategy/IframeProviderStrategy.ts
+++ b/src/core/providers/strategies/IframeProviderStrategy/IframeProviderStrategy.ts
@@ -2,17 +2,17 @@ import { Message, Transaction } from '@multiversx/sdk-core/out';
 import { IframeProvider } from '@multiversx/sdk-web-wallet-iframe-provider/out';
 import { IframeLoginTypes } from '@multiversx/sdk-web-wallet-iframe-provider/out/constants';
 
+import { providerLabels } from 'constants/providerFactory.constants';
 import { PendingTransactionsEventsEnum } from 'core/managers/internal/PendingTransactionsStateManager/types/pendingTransactions.types';
 import { getAccount } from 'core/methods/account/getAccount';
 import { IProvider } from 'core/providers/types/providerFactory.types';
-import { providerLabels } from 'constants/providerFactory.constants';
 import { networkSelector } from 'store/selectors/networkSelectors';
 import { getState } from 'store/store';
 import { ProviderErrorsEnum } from 'types/provider.types';
 import { IframeProviderType } from './types';
+import { BaseProviderStrategy } from '../BaseProviderStrategy/BaseProviderStrategy';
 import { getPendingTransactionsHandlers } from '../helpers/getPendingTransactionsHandlers';
 import { signMessage } from '../helpers/signMessage/signMessage';
-import { BaseProviderStrategy } from '../BaseProviderStrategy/BaseProviderStrategy';
 
 export class IframeProviderStrategy extends BaseProviderStrategy {
   private provider: IframeProvider | null = null;

--- a/src/types/network.types.ts
+++ b/src/types/network.types.ts
@@ -14,11 +14,10 @@ export interface NetworkType {
   roundDuration: number;
   iframeWalletAddress?: string;
   websocketUrl?: string;
-  gasStationMetadata?: {
-    fast: number;
-    faster: number;
-    excellentJustLikeMoveBalance?: number;
-  }[];
+  gasStationMetadata?: Record<
+    number,
+    { lastBlock?: number; fast: number; faster: number }
+  >;
 }
 
 export type CustomNetworkType = {

--- a/src/utils/validation/isContract.ts
+++ b/src/utils/validation/isContract.ts
@@ -1,7 +1,7 @@
+import { Address } from 'lib/sdkCore';
 import { ESDTTransferTypesEnum, TypesOfSmartContractCallsEnum } from 'types';
 import { isStringBase64 } from 'utils/decoders/base64Utils';
 import { addressIsValid } from './addressIsValid';
-import { Address } from 'lib/sdkCore';
 
 export function isContract(
   receiver: string,


### PR DESCRIPTION
### Feature
Add support for dynamically retrieving gas station metadata based on user's shard, allowing DApps to access up-to-date gas price recommendations for transactions.

### Fix

- Introduced getGasStationMetadataFromApi to fetch gas station data from the API
- Implemented initGasStationMetadata to initialize and manage gas station metadata in the app
- Modified the initApp function to call initGasStationMetadata based on the user's shard
- Added logic to only update gas station metadata when necessary (different last block)
- Enhanced NetworkType interface to accommodate new gas station metadata structure

### Additional changes

- Added proper type definitions for gas station metadata
- Implemented caching mechanism to prevent unnecessary API calls

### Contains breaking changes
[x] No

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing