### PR TITLE
Fix wallet connect login issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- [Fix walletConnect login issues](https://github.com/multiversx/mx-sdk-dapp-core/pull/171)
 - [Added sign screens](https://github.com/multiversx/mx-sdk-dapp-core/pull/160)
 - [Fixed provider pending screens](https://github.com/multiversx/mx-sdk-dapp-core/pull/169)
 - [Update package.json and refactor transaction icon handling](https://github.com/multiversx/mx-sdk-dapp-core/pull/170)

--- a/src/core/managers/UnlockPanelManager/UnlockPanelManager.types.ts
+++ b/src/core/managers/UnlockPanelManager/UnlockPanelManager.types.ts
@@ -14,7 +14,7 @@ export enum UnlockPanelEventsEnum {
   /**
    * User clicks Close button inside mounted provider
    */
-  ACNHOR_CLOSE = 'ACNHOR_CLOSE'
+  ANCHOR_CLOSE = 'ANCHOR_CLOSE'
 }
 
 export interface IUnlockPanel {

--- a/src/core/managers/internal/LedgerConnectStateManager/LedgerConnectStateManager.ts
+++ b/src/core/managers/internal/LedgerConnectStateManager/LedgerConnectStateManager.ts
@@ -218,7 +218,7 @@ export class LedgerConnectStateManager extends UIBaseManager<
   public handleClose() {
     if (this.anchor) {
       this.anchor?.dispatchEvent(
-        new CustomEvent(UnlockPanelEventsEnum.ACNHOR_CLOSE, {
+        new CustomEvent(UnlockPanelEventsEnum.ANCHOR_CLOSE, {
           composed: false,
           bubbles: false
         })

--- a/src/core/managers/internal/WalletConnectStateManager/WalletConnectStateManager.ts
+++ b/src/core/managers/internal/WalletConnectStateManager/WalletConnectStateManager.ts
@@ -33,10 +33,14 @@ export class WalletConnectStateManager extends UIBaseManager<
     this.data = { ...this.initialData };
   }
 
-  public handleClose() {
+  public handleClose(options?: { isLoginFinished?: boolean }) {
+    if (options?.isLoginFinished) {
+      return;
+    }
+
     if (this.anchor) {
       this.anchor.dispatchEvent(
-        new CustomEvent(UnlockPanelEventsEnum.ACNHOR_CLOSE, {
+        new CustomEvent(UnlockPanelEventsEnum.ANCHOR_CLOSE, {
           composed: false,
           bubbles: false
         })

--- a/src/core/providers/strategies/BaseProviderStrategy/BaseProviderStrategy.ts
+++ b/src/core/providers/strategies/BaseProviderStrategy/BaseProviderStrategy.ts
@@ -24,15 +24,6 @@ export abstract class BaseProviderStrategy {
       throw new Error(ProviderErrorsEnum.notInitialized);
     }
 
-    const shouldSkipCancelLogin =
-      options &&
-      'shouldSkipCancelLogin' in options &&
-      options.shouldSkipCancelLogin === true;
-
-    if (!shouldSkipCancelLogin) {
-      this.cancelLogin();
-    }
-
     if (this.loginAbortController) {
       this.loginAbortController.abort();
     }

--- a/src/core/providers/strategies/CrossWindowProviderStrategy/CrossWindowProviderStrategy.ts
+++ b/src/core/providers/strategies/CrossWindowProviderStrategy/CrossWindowProviderStrategy.ts
@@ -11,10 +11,7 @@ import { crossWindowConfigSelector } from 'store/selectors';
 import { networkSelector } from 'store/selectors/networkSelectors';
 import { getState } from 'store/store';
 import { ProviderErrorsEnum } from 'types/provider.types';
-import {
-  BaseProviderStrategy,
-  LoginOptionsTypes
-} from '../BaseProviderStrategy/BaseProviderStrategy';
+import { BaseProviderStrategy } from '../BaseProviderStrategy/BaseProviderStrategy';
 import { getPendingTransactionsHandlers } from '../helpers/getPendingTransactionsHandlers';
 import { signMessage } from '../helpers/signMessage/signMessage';
 import { guardTransactions } from '../helpers/signTransactions/helpers/guardTransactions/guardTransactions';
@@ -78,14 +75,6 @@ export class CrossWindowProviderStrategy extends BaseProviderStrategy {
     cancelActionReference?.();
   }
 
-  override login = async (
-    options?: LoginOptionsTypes
-  ): Promise<{ address: string; signature: string }> => {
-    // we are no longer cancelling the login here, because cancelLogin already destroys the provider
-    const loginOptions = { ...options, shouldSkipCancelLogin: true };
-    return super.login(loginOptions);
-  };
-
   private readonly buildProvider = () => {
     if (!this.provider) {
       throw new Error(ProviderErrorsEnum.notInitialized);
@@ -95,7 +84,6 @@ export class CrossWindowProviderStrategy extends BaseProviderStrategy {
     provider.setAccount({ address: this.address });
     provider.signTransactions = this.signTransactions;
     provider.signMessage = this.signMessage;
-    provider.login = this.login;
     provider.cancelLogin = this.cancelLogin;
 
     return provider;

--- a/src/core/providers/strategies/LedgerProviderStrategy/LedgerProviderStrategy.ts
+++ b/src/core/providers/strategies/LedgerProviderStrategy/LedgerProviderStrategy.ts
@@ -76,18 +76,10 @@ export class LedgerProviderStrategy extends BaseProviderStrategy {
     provider.setAccount({ address: this.address });
     provider.signTransactions = this.signTransactions;
     provider.signMessage = this.signMessage;
-    provider.login = this.login;
+    provider.login = this.login.bind(this);
     provider.cancelLogin = this.cancelLogin;
 
     return provider;
-  };
-
-  override login = async (
-    options?: LoginOptionsTypes
-  ): Promise<{ address: string; signature: string }> => {
-    // we are no longer cancelling the login here, because cancelLogin already destroys the provider
-    const loginOptions = { ...options, shouldSkipCancelLogin: true };
-    return super.login(loginOptions);
   };
 
   private readonly ledgerLogin = async (

--- a/src/core/providers/strategies/WalletConnectProviderStrategy/WalletConnectProviderStrategy.ts
+++ b/src/core/providers/strategies/WalletConnectProviderStrategy/WalletConnectProviderStrategy.ts
@@ -205,7 +205,7 @@ export class WalletConnectProviderStrategy {
       );
     }
 
-    const isConnected = await this.provider.isConnected();
+    const isConnected = this.provider.isConnected();
 
     if (isConnected) {
       throw new Error(WalletConnectV2Error.connectError);
@@ -240,7 +240,7 @@ export class WalletConnectProviderStrategy {
 
         const { address = '', signature = '' } = providerInfo ?? {};
 
-        walletConnectManager.handleClose();
+        walletConnectManager.handleClose({ isLoginFinished: Boolean(address) });
         return { address, signature };
       } catch {
         return await reconnect();
@@ -260,7 +260,7 @@ export class WalletConnectProviderStrategy {
       const { address = '', signature = '' } = providerData ?? {};
 
       const walletConnectManager = WalletConnectStateManager.getInstance();
-      walletConnectManager.handleClose();
+      walletConnectManager.handleClose({ isLoginFinished: Boolean(address) });
       return { address, signature };
     } catch (error) {
       console.error(WalletConnectV2Error.userRejected, error);


### PR DESCRIPTION
### Issue
destroy is being called after login which resets accountProvider to null.

### Fix
add new flag in order to not reset the account provider

### Additional changes

### Contains breaking changes
[x] No

[] Yes

### Updated CHANGELOG
[x] Yes

### Testing
[x] User testing
[] Unit tests
